### PR TITLE
remove the PROJECT_NAME option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
 # Options:
-#    PROJECT_NAME                   default: lexbor
 #    LEXBOR_OPTIMIZATION_LEVEL      default: -O2
 #    LEXBOR_C_FLAGS                 default: see this file
 #    LEXBOR_WITHOUT_THREADS         default: ON; Not used now, for the future
@@ -14,9 +13,7 @@ cmake_minimum_required(VERSION 3.0)
 #                                    Used with LEXBOR_BUILD_TESTS
 #    LEXBOR_BUILD_EXAMPLES          default: OFF; Build all examples
 
-if(NOT DEFINED PROJECT_NAME)
 set(PROJECT_NAME "lexbor")
-endif()
 
 project(${PROJECT_NAME} C)
 


### PR DESCRIPTION
This pull request removes the option to set a custom PROJECT_NAME for lexbor, I would like to talk about why this option should be removed first, so that you can consider if the pull request should be accepted.

Say I want to create a cmake project, with lexbor added as a subdirectory. This is the structure of the project.

```
.
├── build
├── CMakeLists.txt
├── lexbor
└── main.cpp
```

The contents of CMakeLists.txt are as follows.

## CMakeLists.txt
```cmake
cmake_minimum_required(VERSION 3.12)
project(CMakeTest)

set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")

add_subdirectory(lexbor lexbor-build)
include_directories(lexbor/source)

add_executable(CMakeTest main.cpp)
target_link_libraries(CMakeTest lexbor)
```

Then I tried building the project.

```bash
cd build
cmake ..
make
```

However you will notice that the project cannot be built, an error was thrown.

```
/usr/bin/ld: cannot find -llexbor
```

Yes, liblexbor.so was not built. The reason why it was not build was that PROJECT_NAME was defaulted as the same as the parent's, in other words, we have two targets with the same name, but CMake will only choose one, it chooses the parent project, so the subproject - lexbor - was not built.

There are two solutions. One is set the project name in the parent's CMakeLists.txt before adding the subdirectory, and set it back after adding it.

```cmake
set(PROJECT_NAME lexbor CACHE STRING "project name" FORCE)
add_subdirectory(lexbor lexbor-build)
set(PROJECT_NAME CMakeTest CACHE STRING "project name" FORCE)
```

The other one is to set the project name explicitly in lexbor's CMakeLists.txt.

```cmake
set(PROJECT_NAME "lexbor")
```

I think the second one is more appropriate, and it saves a lot of time for users, who have to spend some time to figure out why liblexbor.so is not built.
