### PR TITLE
elements_by_attr.c example: make print_collection_elements() static

### DIFF
--- a/examples/lexbor/html/elements_by_attr.c
+++ b/examples/lexbor/html/elements_by_attr.c
@@ -9,7 +9,7 @@
 #include <lexbor/dom/collection.h>
 
 
-void
+static void
 print_collection_elements(lxb_dom_collection_t *collection)
 {
     lxb_dom_element_t *element;


### PR DESCRIPTION
this remove a warning (print_collection_elements() not previously
declared)