### PR TITLE
add helper functions

### DIFF
--- a/source/lexbor/dom/collection.c
+++ b/source/lexbor/dom/collection.c
@@ -64,6 +64,12 @@ lxb_dom_collection_destroy(lxb_dom_collection_t *col, bool self_destroy)
 /*
  * No inline functions for ABI.
  */
+lxb_dom_collection_t *
+lxb_dom_collection_make_noi(lxb_dom_document_t *document, size_t start_list_size)
+{
+    return lxb_dom_collection_make(document, start_list_size);
+}
+
 void
 lxb_dom_collection_clean_noi(lxb_dom_collection_t *col)
 {

--- a/source/lexbor/dom/collection.h
+++ b/source/lexbor/dom/collection.h
@@ -86,6 +86,9 @@ lxb_dom_collection_length(lxb_dom_collection_t *col)
 /*
  * No inline functions for ABI.
  */
+lxb_dom_collection_t *
+lxb_dom_collection_make_noi(lxb_dom_document_t *document, size_t start_list_size);
+
 void
 lxb_dom_collection_clean_noi(lxb_dom_collection_t *col);
 

--- a/source/lexbor/dom/interfaces/node.c
+++ b/source/lexbor/dom/interfaces/node.c
@@ -432,37 +432,37 @@ lxb_dom_node_text_content_set(lxb_dom_node_t *node,
 }
 
 unsigned int
-lxb_dom_node_tag_id(lxb_dom_node_t *node)
+lxb_dom_node_tag_id_noi(lxb_dom_node_t *node)
 {
-  return node->tag_id;
+    return lxb_dom_node_tag_id(node);
 }
 
 lxb_dom_node_t *
-lxb_dom_node_next(lxb_dom_node_t *node)
+lxb_dom_node_next_noi(lxb_dom_node_t *node)
 {
-  return node->next;
+    return lxb_dom_node_next(node);
 }
 
 lxb_dom_node_t *
-lxb_dom_node_prev(lxb_dom_node_t *node)
+lxb_dom_node_prev_noi(lxb_dom_node_t *node)
 {
-  return node->prev;
+    return lxb_dom_node_prev(node);
 }
 
 lxb_dom_node_t *
-lxb_dom_node_parent(lxb_dom_node_t *node)
+lxb_dom_node_parent_noi(lxb_dom_node_t *node)
 {
-  return node->parent;
+    return lxb_dom_node_parent(node);
 }
 
 lxb_dom_node_t *
-lxb_dom_node_first_child(lxb_dom_node_t *node)
+lxb_dom_node_first_child_noi(lxb_dom_node_t *node)
 {
-  return node->first_child;
+    return lxb_dom_node_first_child(node);
 }
 
 lxb_dom_node_t *
-lxb_dom_node_last_child(lxb_dom_node_t *node)
+lxb_dom_node_last_child_noi(lxb_dom_node_t *node)
 {
-  return node->last_child;
+    return lxb_dom_node_last_child(node);
 }

--- a/source/lexbor/dom/interfaces/node.c
+++ b/source/lexbor/dom/interfaces/node.c
@@ -430,3 +430,39 @@ lxb_dom_node_text_content_set(lxb_dom_node_t *node,
 
     return LXB_STATUS_OK;
 }
+
+unsigned int
+lxb_dom_node_tag_id(lxb_dom_node_t *node)
+{
+  return node->tag_id;
+}
+
+lxb_dom_node_t *
+lxb_dom_node_next(lxb_dom_node_t *node)
+{
+  return node->next;
+}
+
+lxb_dom_node_t *
+lxb_dom_node_prev(lxb_dom_node_t *node)
+{
+  return node->prev;
+}
+
+lxb_dom_node_t *
+lxb_dom_node_parent(lxb_dom_node_t *node)
+{
+  return node->parent;
+}
+
+lxb_dom_node_t *
+lxb_dom_node_first_child(lxb_dom_node_t *node)
+{
+  return node->first_child;
+}
+
+lxb_dom_node_t *
+lxb_dom_node_last_child(lxb_dom_node_t *node)
+{
+  return node->last_child;
+}

--- a/source/lexbor/dom/interfaces/node.h
+++ b/source/lexbor/dom/interfaces/node.h
@@ -93,24 +93,6 @@ LXB_API void
 lxb_dom_node_simple_walk(lxb_dom_node_t *root,
                          lxb_dom_node_simple_walker_f walker_cb, void *ctx);
 
-LXB_API unsigned int
-lxb_dom_node_tag_id(lxb_dom_node_t *node);
-
-LXB_API lxb_dom_node_t *
-lxb_dom_node_next(lxb_dom_node_t *node);
-
-LXB_API lxb_dom_node_t *
-lxb_dom_node_prev(lxb_dom_node_t *node);
-
-LXB_API lxb_dom_node_t *
-lxb_dom_node_parent(lxb_dom_node_t *node);
-
-LXB_API lxb_dom_node_t *
-lxb_dom_node_first_child(lxb_dom_node_t *node);
-
-LXB_API lxb_dom_node_t *
-lxb_dom_node_last_child(lxb_dom_node_t *node);
-
 /*
  * Memory of returns value will be freed in document destroy moment.
  * If you need to release returned resource after use, then call the
@@ -122,6 +104,66 @@ lxb_dom_node_text_content(lxb_dom_node_t *node, size_t *len);
 LXB_API lxb_status_t
 lxb_dom_node_text_content_set(lxb_dom_node_t *node,
                               const lxb_char_t *content, size_t len);
+
+/*
+ * Inline functions
+ */
+lxb_inline unsigned int
+lxb_dom_node_tag_id(lxb_dom_node_t *node)
+{
+    return node->tag_id;
+}
+
+lxb_inline lxb_dom_node_t *
+lxb_dom_node_next(lxb_dom_node_t *node)
+{
+    return node->next;
+}
+
+lxb_inline lxb_dom_node_t *
+lxb_dom_node_prev(lxb_dom_node_t *node)
+{
+    return node->prev;
+}
+
+lxb_inline lxb_dom_node_t *
+lxb_dom_node_parent(lxb_dom_node_t *node)
+{
+    return node->parent;
+}
+
+lxb_inline lxb_dom_node_t *
+lxb_dom_node_first_child(lxb_dom_node_t *node)
+{
+    return node->first_child;
+}
+
+lxb_inline lxb_dom_node_t *
+lxb_dom_node_last_child(lxb_dom_node_t *node)
+{
+    return node->last_child;
+}
+
+/*
+ * No inline functions for ABI.
+ */
+unsigned int
+lxb_dom_node_tag_id_noi(lxb_dom_node_t *node);
+
+lxb_dom_node_t *
+lxb_dom_node_next_noi(lxb_dom_node_t *node);
+
+lxb_dom_node_t *
+lxb_dom_node_prev_noi(lxb_dom_node_t *node);
+
+lxb_dom_node_t *
+lxb_dom_node_parent_noi(lxb_dom_node_t *node);
+
+lxb_dom_node_t *
+lxb_dom_node_first_child_noi(lxb_dom_node_t *node);
+
+lxb_dom_node_t *
+lxb_dom_node_last_child_noi(lxb_dom_node_t *node);
 
 
 #ifdef __cplusplus

--- a/source/lexbor/dom/interfaces/node.h
+++ b/source/lexbor/dom/interfaces/node.h
@@ -93,6 +93,24 @@ LXB_API void
 lxb_dom_node_simple_walk(lxb_dom_node_t *root,
                          lxb_dom_node_simple_walker_f walker_cb, void *ctx);
 
+LXB_API unsigned int
+lxb_dom_node_tag_id(lxb_dom_node_t *node);
+
+LXB_API lxb_dom_node_t *
+lxb_dom_node_next(lxb_dom_node_t *node);
+
+LXB_API lxb_dom_node_t *
+lxb_dom_node_prev(lxb_dom_node_t *node);
+
+LXB_API lxb_dom_node_t *
+lxb_dom_node_parent(lxb_dom_node_t *node);
+
+LXB_API lxb_dom_node_t *
+lxb_dom_node_first_child(lxb_dom_node_t *node);
+
+LXB_API lxb_dom_node_t *
+lxb_dom_node_last_child(lxb_dom_node_t *node);
+
 /*
  * Memory of returns value will be freed in document destroy moment.
  * If you need to release returned resource after use, then call the


### PR DESCRIPTION
Hi, i'm trying to use lexbor in my crystal wrapper, this functions helps. It seems this parser 15% faster and less memory used, also binary size with static library smaller by 1Mb.
Question, is it support skip whitespace nodes?
Also, waiting css selectors feature.