### PR TITLE
Added some helper methods

### DIFF
--- a/source/lexbor/dom/interfaces/document.c
+++ b/source/lexbor/dom/interfaces/document.c
@@ -374,3 +374,9 @@ lxb_dom_document_destroy_text_noi(lxb_dom_document_t *document,
 {
     return lxb_dom_document_destroy_text(document, text);
 }
+
+lxb_dom_element_t *
+lxb_dom_document_element_noi(lxb_dom_document_t *document)
+{
+    return lxb_dom_document_element(document);
+}

--- a/source/lexbor/dom/interfaces/document.h
+++ b/source/lexbor/dom/interfaces/document.h
@@ -153,6 +153,12 @@ lxb_dom_document_destroy_text(lxb_dom_document_t *document, lxb_char_t *text)
     return lexbor_mraw_free(document->text, text);
 }
 
+lxb_inline lxb_dom_element_t *
+lxb_dom_document_element(lxb_dom_document_t *document)
+{
+    return document->element;
+}
+
 /*
  * No inline functions for ABI.
  */
@@ -177,6 +183,9 @@ lxb_dom_document_create_text_noi(lxb_dom_document_t *document, size_t len);
 void *
 lxb_dom_document_destroy_text_noi(lxb_dom_document_t *document,
                                   lxb_char_t *text);
+
+lxb_dom_element_t *
+lxb_dom_document_element_noi(lxb_dom_document_t *document);
 
 
 #ifdef __cplusplus

--- a/source/lexbor/html/serialize.c
+++ b/source/lexbor/html/serialize.c
@@ -46,11 +46,7 @@ lxb_html_serialize_ctx_t;
 static lxb_status_t
 lxb_html_serialize_str_callback(const lxb_char_t *data, size_t len, void *ctx);
 
-static lxb_status_t
-lxb_html_serialize_node_cb(lxb_dom_node_t *node,
-                           lxb_html_serialize_cb_f cb, void *ctx);
-
-lxb_inline lxb_status_t
+bool
 lxb_html_serialize_node_is_void(lxb_dom_node_t *node);
 
 static lxb_status_t
@@ -244,7 +240,7 @@ lxb_html_serialize_tree_str(lxb_dom_node_t *node, lexbor_str_t *str)
                                       lxb_html_serialize_str_callback, &ctx);
 }
 
-static lxb_status_t
+lxb_status_t
 lxb_html_serialize_node_cb(lxb_dom_node_t *node,
                            lxb_html_serialize_cb_f cb, void *ctx)
 {
@@ -317,7 +313,7 @@ lxb_html_serialize_node_cb(lxb_dom_node_t *node,
     return LXB_STATUS_OK;
 }
 
-lxb_inline lxb_status_t
+bool
 lxb_html_serialize_node_is_void(lxb_dom_node_t *node)
 {
     if (node->ns != LXB_NS_HTML) {

--- a/source/lexbor/html/serialize.h
+++ b/source/lexbor/html/serialize.h
@@ -47,6 +47,10 @@ lxb_html_serialize_tree_cb(lxb_dom_node_t *node,
                            lxb_html_serialize_cb_f cb, void *ctx);
 
 LXB_API lxb_status_t
+lxb_html_serialize_node_cb(lxb_dom_node_t *node,
+                           lxb_html_serialize_cb_f cb, void *ctx);
+
+LXB_API lxb_status_t
 lxb_html_serialize_tree_str(lxb_dom_node_t *node, lexbor_str_t *str);
 
 LXB_API lxb_status_t
@@ -68,7 +72,6 @@ LXB_API lxb_status_t
 lxb_html_serialize_pretty_tree_str(lxb_dom_node_t *node,
                                    lxb_html_serialize_opt_t opt, size_t indent,
                                    lexbor_str_t *str);
-
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
related to 3 fuctions:
* added lxb_dom_document_element_noi

* lxb_html_serialize_node_cb needed to be public to serialize node as tree, and lxb_html_serialize_tree_cb bad for it, because not serialize node itself(can only be used for document node) and lxb_html_serialize_cb not go deeper.

* fix return type for lxb_html_serialize_node_is_void and make it not inline, to use in api.