### PR TITLE
def.h: Use extern even for static

### DIFF
--- a/source/lexbor/core/def.h
+++ b/source/lexbor/core/def.h
@@ -52,14 +52,10 @@
     #define LXB_API
 #endif
 
-#ifndef LEXBOR_STATIC
-    #ifdef _WIN32
-        #define LXB_EXTERN extern __declspec(dllimport)
-    #else
-        #define LXB_EXTERN extern
-    #endif
+#ifdef _WIN32
+    #define LXB_EXTERN extern __declspec(dllimport)
 #else
-    #define LXB_EXTERN
+    #define LXB_EXTERN extern
 #endif
 
 #endif /* LEXBOR_DEF_H */


### PR DESCRIPTION
This fixes static-linking with another library on a machine running gcc-10

(untested on Windows)

See: https://git.pleroma.social/pleroma/elixir-libraries/fast_html/-/issues/8