### PR TITLE
Examples: fix node iteration in html2sexpr

### DIFF
--- a/examples/lexbor/html/html2sexpr.c
+++ b/examples/lexbor/html/html2sexpr.c
@@ -88,7 +88,7 @@ tree_walker(lxb_dom_node_t *node, lxb_html_serialize_cb_f cb, void *ctx)
 {
     lxb_status_t status;
     lxb_html_template_element_t *temp;
-    lxb_dom_node_t *root = node;
+    lxb_dom_node_t *root = node->parent;
 
     const lxb_char_t *name;
     size_t name_len = 0;


### PR DESCRIPTION
This example terminates immediately if the first child node in the
document is of type LXB_DOM_NODE_TYPE_DOCUMENT_TYPE, because it has no
children or siblings. By setting the root item to the actual document
node, we ensure that all nodes are visited.