### PR TITLE
Fix for the global umbrella header

### DIFF
--- a/source/lexbor/core/core.h
+++ b/source/lexbor/core/core.h
@@ -29,6 +29,6 @@
 #include "lexbor/core/utils.h"
 #include "lexbor/core/diyfp.h"
 #include "lexbor/core/dtoa.h"
-#include "lexbor/core/strpod.h"
+#include "lexbor/core/strtod.h"
 
 #endif /* LEXBOR_CORE_H */

--- a/source/lexbor/css/syntax/state_res.h
+++ b/source/lexbor/css/syntax/state_res.h
@@ -7,6 +7,9 @@
 #ifndef LEXBOR_CSS_SYNTAX_STATE_RES_H
 #define LEXBOR_CSS_SYNTAX_STATE_RES_H
 
+#include "lexbor/css/syntax/state.h"
+#include "lexbor/css/syntax/consume.h"
+
 
 static const lxb_css_syntax_tokenizer_state_f
 lxb_css_syntax_state_res_map[256] =


### PR DESCRIPTION
👋 I found that each module contains some kind of an umbrella header and tried to check that the global umbrella for this library will work.

So, I've got some list of errors with the following example, and founded out that it isn't hard to fix.

```c
// lexbor.h - umbrella header
#include <lexbor/core/core.h>
#include <lexbor/css/css.h>
#include <lexbor/encoding/encoding.h>
#include <lexbor/ns/ns.h>
#include <lexbor/tag/tag.h>
#include <lexbor/utils/utils.h>
#include <lexbor/dom/dom.h>
#include <lexbor/html/html.h>
```

```c
#include "lexbor.h"

int main() {
    lxb_status_t status;
    const lxb_char_t *tag_name;
    lxb_html_document_t *document;
    static const lxb_char_t html[] = "<div>Work fine!</div>";
    size_t html_len = sizeof(html) - 1;
    document = lxb_html_document_create();
    if (document == NULL) { exit(EXIT_FAILURE); }
    status = lxb_html_document_parse(document, html, html_len);
    if (status != LXB_STATUS_OK) { exit(EXIT_FAILURE); }
    tag_name = lxb_dom_element_qualified_name(lxb_dom_interface_element(document->body), NULL);
    printf("Element tag name: %s\n", tag_name);
    lxb_html_document_destroy(document);
    return EXIT_SUCCESS;
}
```

Generally the next error is repeated many times.
```
/usr/local/include/lexbor/css/syntax/state_res.h:14:5: error: use of undeclared identifier 'lxb_css_syntax_state_eof'; did you mean 'lxb_css_syntax_state_res_map'?
    lxb_css_syntax_state_eof, /* 0x00; 'NUL'; NULL */
    ^~~~~~~~~~~~~~~~~~~~~~~~
    lxb_css_syntax_state_res_map
```

I checked that the library is building very well, all tests passed, and an example is working.
```
cmake -H. -Bbuild -DLEXBOR_BUILD_TESTS=ON -DLEXBOR_BUILD_SEPARATELY=OFF
cmake --build build
cd build && make test

cmake -H. -Bbuild -DLEXBOR_BUILD_TESTS=ON -DLEXBOR_BUILD_SEPARATELY=ON
cmake --build build
cd build && make test
```

Overall, the global umbrella will be very useful to make wrappers for this library. 📚 Let me know if I understood something wrong.