### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/lexbor/html/element_attributes.c
+++ b/examples/lexbor/html/element_attributes.c
@@ -42,7 +42,7 @@ main(int argc, const char *argv[])
         FAILED("Failed to create collection");
     }
 
-    /* Get BODY elemenet (root for search) */
+    /* Get BODY element (root for search) */
     body = lxb_html_document_body_element(document);
     element = lxb_dom_interface_element(body);
 
@@ -54,7 +54,7 @@ main(int argc, const char *argv[])
         FAILED("Failed to find DIV element");
     }
 
-    /* Append new attrtitube */
+    /* Append new attribute */
     element = lxb_dom_collection_element(collection, 0);
 
     attr = lxb_dom_element_set_attribute(element, name, name_size,
@@ -119,7 +119,7 @@ main(int argc, const char *argv[])
     printf("Element after attribute \"%s\" change: ", name);
     serialize_node(lxb_dom_interface_node(element));
 
-    /* Remove new attrtitube by name */
+    /* Remove new attribute by name */
     lxb_dom_element_remove_attribute(element, name, name_size);
 
     /* Print Result */

--- a/examples/lexbor/html/element_innerHTML.c
+++ b/examples/lexbor/html/element_innerHTML.c
@@ -29,7 +29,7 @@ main(int argc, const char *argv[])
     PRINT("\nTree after parse:");
     serialize(lxb_dom_interface_node(document));
 
-    /* Get BODY elemenet */
+    /* Get BODY element */
     body = lxb_html_document_body_element(document);
 
     PRINT("\nHTML for innerHTML:");

--- a/source/lexbor/core/strtod.c
+++ b/source/lexbor/core/strtod.c
@@ -219,7 +219,7 @@ lexbor_strtod_diyfp_strtod(const lxb_char_t *start, size_t length, int exp)
 
     /*
      * Check whether the double's significand changes when the error is added
-     * or substracted.
+     * or subtracted.
      */
 
     magnitude = LEXBOR_DIYFP_SIGNIFICAND_SIZE + value.exp;

--- a/source/lexbor/html/tree.c
+++ b/source/lexbor/html/tree.c
@@ -211,7 +211,7 @@ lxb_html_tree_token_callback(lxb_html_tokenizer_t *tkz,
     return token;
 }
 
-/* TODO: not complite!!! */
+/* TODO: not complete!!! */
 lxb_status_t
 lxb_html_tree_stop_parsing(lxb_html_tree_t *tree)
 {

--- a/test/lexbor/html/attributes.c
+++ b/test/lexbor/html/attributes.c
@@ -43,7 +43,7 @@ TEST_BEGIN(attrs)
     collection = lxb_dom_collection_make(&document->dom_document, 16);
     test_ne(collection, NULL);
 
-    /* Get BODY elemenet (root for search) */
+    /* Get BODY element (root for search) */
     body = lxb_html_document_body_element(document);
     element = lxb_dom_interface_element(body);
 
@@ -54,7 +54,7 @@ TEST_BEGIN(attrs)
     test_eq(status, LXB_STATUS_OK);
     test_ne(lxb_dom_collection_length(collection), 0);
 
-    /* Append new attrtitube */
+    /* Append new attribute */
     element = lxb_dom_collection_element(collection, 0);
 
     i = 0;
@@ -83,7 +83,7 @@ TEST_BEGIN(attrs)
 
         test_eq(status, LXB_STATUS_OK);
 
-        /* Remove new attrtitube by name */
+        /* Remove new attribute by name */
         lxb_dom_element_remove_attribute(element, name, size);
     }
 

--- a/test/lexbor/html/clone.c
+++ b/test/lexbor/html/clone.c
@@ -68,7 +68,7 @@ TEST_BEGIN(single_clone)
 
     test_eq(lxb_dom_collection_length(collection), 2);
 
-    /* Get cloned attribete. */
+    /* Get cloned attribute. */
 
     attr_cloned = lxb_dom_element_attr_by_name(lxb_dom_interface_element(clone),
                                                (lxb_char_t *) "x", 1);


### PR DESCRIPTION
There are small typos in:
- examples/lexbor/html/element_attributes.c
- examples/lexbor/html/element_innerHTML.c
- source/lexbor/core/strtod.c
- source/lexbor/html/tree.c
- test/lexbor/html/attributes.c
- test/lexbor/html/clone.c

Fixes:
- Should read `attribute` rather than `attrtitube`.
- Should read `element` rather than `elemenet`.
- Should read `subtracted` rather than `substracted`.
- Should read `complete` rather than `complite`.
- Should read `attribute` rather than `attribete`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md