### PR TITLE
Fix c++11-narrowing warnings/errors

### DIFF
--- a/source/lexbor/core/diyfp.h
+++ b/source/lexbor/core/diyfp.h
@@ -24,7 +24,7 @@ extern "C" {
 
 
 #define lexbor_diyfp(_s, _e)           (lexbor_diyfp_t)                        \
-                                       { .significand = (_s), .exp = (_e) }
+                                       { .significand = (_s), .exp = (int) (_e) }
 #define lexbor_uint64_hl(h, l)   (((uint64_t) (h) << 32) + (l))
 
 


### PR DESCRIPTION
With Apple Clang, the `core/diyfp.h` header throws a lot of c++11-narrowing warnings (or errors with `-Werror`):

```
In file included from test.cpp:1:
./../source/lexbor/core/diyfp.h:180:12: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
    return lexbor_diyfp(v.significand << shift, v.exp - shift);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../source/lexbor/core/diyfp.h:27:70: note: expanded from macro 'lexbor_diyfp'
                                       { .significand = (_s), .exp = (_e) }
                                                                     ^~~~
./../source/lexbor/core/diyfp.h:180:12: note: insert an explicit cast to silence this issue
    return lexbor_diyfp(v.significand << shift, v.exp - shift);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../source/lexbor/core/diyfp.h:27:70: note: expanded from macro 'lexbor_diyfp'
                                       { .significand = (_s), .exp = (_e) }
                                                                     ^~~~
./../source/lexbor/core/diyfp.h:186:12: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
    return lexbor_diyfp(v.significand >> shift, v.exp + shift);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../source/lexbor/core/diyfp.h:27:70: note: expanded from macro 'lexbor_diyfp'
                                       { .significand = (_s), .exp = (_e) }
                                                                     ^~~~
./../source/lexbor/core/diyfp.h:186:12: note: insert an explicit cast to silence this issue
    return lexbor_diyfp(v.significand >> shift, v.exp + shift);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../source/lexbor/core/diyfp.h:27:70: note: expanded from macro 'lexbor_diyfp'
                                       { .significand = (_s), .exp = (_e) }
                                                                     ^~~~
2 errors generated.
```

An explicit cast in the `lexbor_diyfp()` macro fixes that. Instead of a cast, one could also change the struct's `.exp` property to unsigned, but I don't know what other consequences that would have.