### PR TITLE
Fix MSVC error C4576 in C++ mode

### DIFF
--- a/source/lexbor/core/diyfp.h
+++ b/source/lexbor/core/diyfp.h
@@ -23,8 +23,12 @@ extern "C" {
 #include <math.h>
 
 
+#ifdef __cplusplus
+#define lexbor_diyfp(_s, _e)           { .significand = (_s), .exp = (int) (_e) }
+#else
 #define lexbor_diyfp(_s, _e)           (lexbor_diyfp_t)                        \
                                        { .significand = (_s), .exp = (int) (_e) }
+#endif
 #define lexbor_uint64_hl(h, l)   (((uint64_t) (h) << 32) + (l))
 
 


### PR DESCRIPTION
When diyfp.h is included in a C++ file, MSVC errors out with:

```
lexbor/core/diyfp.h(238): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
```

I couldn't come up with a better workaround than to use a simple initializer list in C++ mode and keep the previous struct cast in C99 etc. mode, but at least it works. Better ideas welcome.