### PR TITLE
Prevent crash when selecting NULL-valued attributes

### DIFF
--- a/source/lexbor/dom/interfaces/element.c
+++ b/source/lexbor/dom/interfaces/element.c
@@ -847,6 +847,7 @@ lxb_dom_elements_by_class_name_cb(lxb_dom_node_t *node, void *ctx)
     lxb_dom_element_t *el = lxb_dom_interface_element(node);
 
     if (el->attr_class == NULL
+        || el->attr_class->value == NULL
         || el->attr_class->value->length < cb_ctx->value_length)
     {
         return LEXBOR_ACTION_OK;
@@ -1078,7 +1079,7 @@ lxb_dom_elements_by_attr_cb(lxb_dom_node_t *node, void *ctx)
         return LEXBOR_ACTION_OK;
     }
 
-    if ((cb_ctx->value_length == 0 && attr->value->length == 0)
+    if ((cb_ctx->value_length == 0 && (attr->value == NULL || attr->value->length == 0))
         || cb_ctx->cmp_func(cb_ctx, attr))
     {
         cb_ctx->status = lxb_dom_collection_append(cb_ctx->col, node);
@@ -1095,63 +1096,63 @@ static bool
 lxb_dom_elements_by_attr_cmp_full(lxb_dom_element_cb_ctx_t *ctx,
                                   lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length == attr->value->length
+    if (attr->value != NULL && ctx->value_length == attr->value->length
         && lexbor_str_data_ncmp(attr->value->data, ctx->value,
                                 ctx->value_length))
     {
         return true;
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 static bool
 lxb_dom_elements_by_attr_cmp_full_case(lxb_dom_element_cb_ctx_t *ctx,
                                        lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length == attr->value->length
+    if (attr->value != NULL && ctx->value_length == attr->value->length
         && lexbor_str_data_ncasecmp(attr->value->data, ctx->value,
                                     ctx->value_length))
     {
         return true;
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 static bool
 lxb_dom_elements_by_attr_cmp_begin(lxb_dom_element_cb_ctx_t *ctx,
                                    lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length <= attr->value->length
+    if (attr->value != NULL && ctx->value_length <= attr->value->length
         && lexbor_str_data_ncmp(attr->value->data, ctx->value,
                                 ctx->value_length))
     {
         return true;
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 static bool
 lxb_dom_elements_by_attr_cmp_begin_case(lxb_dom_element_cb_ctx_t *ctx,
                                         lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length <= attr->value->length
+    if (attr->value != NULL && ctx->value_length <= attr->value->length
         && lexbor_str_data_ncasecmp(attr->value->data,
                                     ctx->value, ctx->value_length))
     {
         return true;
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 static bool
 lxb_dom_elements_by_attr_cmp_end(lxb_dom_element_cb_ctx_t *ctx,
                                  lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length <= attr->value->length) {
+    if (attr->value != NULL && ctx->value_length <= attr->value->length) {
         size_t dif = attr->value->length - ctx->value_length;
 
         if (lexbor_str_data_ncmp_end(&attr->value->data[dif],
@@ -1161,14 +1162,14 @@ lxb_dom_elements_by_attr_cmp_end(lxb_dom_element_cb_ctx_t *ctx,
         }
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 static bool
 lxb_dom_elements_by_attr_cmp_end_case(lxb_dom_element_cb_ctx_t *ctx,
                                       lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length <= attr->value->length) {
+    if (attr->value != NULL && ctx->value_length <= attr->value->length) {
         size_t dif = attr->value->length - ctx->value_length;
 
         if (lexbor_str_data_ncasecmp_end(&attr->value->data[dif],
@@ -1178,35 +1179,35 @@ lxb_dom_elements_by_attr_cmp_end_case(lxb_dom_element_cb_ctx_t *ctx,
         }
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 static bool
 lxb_dom_elements_by_attr_cmp_contain(lxb_dom_element_cb_ctx_t *ctx,
                                      lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length <= attr->value->length
+    if (attr->value != NULL && ctx->value_length <= attr->value->length
         && lexbor_str_data_ncmp_contain(attr->value->data, attr->value->length,
                                         ctx->value, ctx->value_length))
     {
         return true;
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 static bool
 lxb_dom_elements_by_attr_cmp_contain_case(lxb_dom_element_cb_ctx_t *ctx,
                                           lxb_dom_attr_t *attr)
 {
-    if (ctx->value_length <= attr->value->length
+    if (attr->value != NULL && ctx->value_length <= attr->value->length
         && lexbor_str_data_ncasecmp_contain(attr->value->data, attr->value->length,
                                             ctx->value, ctx->value_length))
     {
         return true;
     }
 
-    return false;
+    return attr->value == NULL && ctx->value_length == 0;
 }
 
 const lxb_char_t *

--- a/source/lexbor/selectors/selectors.c
+++ b/source/lexbor/selectors/selectors.c
@@ -743,7 +743,7 @@ lxb_selectors_match(lxb_selectors_t *selectors, lxb_selectors_entry_t *entry,
         case LXB_CSS_SELECTOR_TYPE_ID:
             element = lxb_dom_interface_element(node);
 
-            if (element->attr_id == NULL) {
+            if (element->attr_id == NULL || element->attr_id->value == NULL) {
                 return false;
             }
 
@@ -761,7 +761,7 @@ lxb_selectors_match(lxb_selectors_t *selectors, lxb_selectors_entry_t *entry,
         case LXB_CSS_SELECTOR_TYPE_CLASS:
             element = lxb_dom_interface_element(node);
 
-            if (element->attr_class == NULL) {
+            if (element->attr_class == NULL || element->attr_class->value == NULL) {
                 return false;
             }
 

--- a/test/lexbor/html/element_by.c
+++ b/test/lexbor/html/element_by.c
@@ -9,6 +9,30 @@
 
 #include <unit/test.h>
 
+static const lxb_char_t data[] = "<html><head></head><body>"
+                                 "<div class='with-accordion'>1</div>"
+                                 "<div class='with-accordion hidden'>2</div>"
+                                 "<div class='hidden with-accordion'>3</div>"
+                                 "<div class='hidden with-accordion hidden'>4</div>"
+                                 "<div class='    with-accordion'>5</div>"
+                                 "<div class='with-accordion      '>6</div>"
+                                 "<div class='hidden    hidden  with-accordion'>7</div>"
+                                 "<div class='with-accordion    hidden'>8</div>"
+                                 "<div class='wewith-accordion'></div>"
+                                 "<div class='with-accordionwe'></div>"
+                                 "<div class='wewith-accordionwe'></div>"
+                                 "<div class='with- accordion'></div>"
+                                 "<div class></div>"
+                                 "<div class=''></div>"
+                                 "<div id></div>"
+                                 "<div id=''></div>"
+                                 "<div id='abc'></div>"
+                                 "<div foo></div>"
+                                 "<div foo=''></div>"
+                                 "<div foo='abc'></div>"
+                                 "</body></html>";
+
+static const size_t data_len = sizeof(data) - 1;
 
 TEST_BEGIN(by_class)
 {
@@ -16,27 +40,10 @@ TEST_BEGIN(by_class)
     lxb_html_document_t *document;
     lxb_dom_collection_t *collection;
 
-    lxb_char_t data[] = "<html><head></head><body>"
-                        "<div class='with-accordion'>1</div>"
-                        "<div class='with-accordion hidden'>2</div>"
-                        "<div class='hidden with-accordion'>3</div>"
-                        "<div class='hidden with-accordion hidden'>4</div>"
-                        "<div class='    with-accordion'>5</div>"
-                        "<div class='with-accordion      '>6</div>"
-                        "<div class='hidden    hidden  with-accordion'>7</div>"
-                        "<div class='with-accordion    hidden'>8</div>"
-                        "<div class='wewith-accordion'></div>"
-                        "<div class='with-accordionwe'></div>"
-                        "<div class='wewith-accordionwe'></div>"
-                        "<div class='with- accordion'></div>"
-                        "</body></html>";
-
-    size_t len = sizeof(data) - 1;
-
     document = lxb_html_document_create();
     test_ne(document, NULL);
 
-    status = lxb_html_document_parse(document, data, len);
+    status = lxb_html_document_parse(document, data, data_len);
     test_eq(status, LXB_STATUS_OK);
 
     collection = lxb_dom_collection_make(&document->dom_document, 16);
@@ -46,7 +53,80 @@ TEST_BEGIN(by_class)
                                             collection,
                                             (lxb_char_t *) "with-accordion", 14);
     test_eq(status, LXB_STATUS_OK);
+    test_eq(lxb_dom_collection_length(collection), 8);
 
+    // Empty class (doesn't select anything, but shouldn't crash either)
+    status = lxb_dom_elements_by_class_name(lxb_dom_interface_element(document),
+                                            collection,
+                                            (lxb_char_t *) "", 0);
+    test_eq(status, LXB_STATUS_OK);
+    test_eq(lxb_dom_collection_length(collection), 8);
+
+    // Empty class with NULL
+    status = lxb_dom_elements_by_class_name(lxb_dom_interface_element(document),
+                                            collection,
+                                            (lxb_char_t *) NULL, 0);
+    test_eq(status, LXB_STATUS_OK);
+    test_eq(lxb_dom_collection_length(collection), 8);
+
+    lxb_dom_collection_destroy(collection, true);
+    lxb_html_document_destroy(document);
+}
+TEST_END
+
+TEST_BEGIN(by_attr)
+{
+    lxb_status_t status;
+    lxb_html_document_t *document;
+    lxb_dom_collection_t *collection;
+
+    document = lxb_html_document_create();
+    test_ne(document, NULL);
+
+    status = lxb_html_document_parse(document, data, data_len);
+    test_eq(status, LXB_STATUS_OK);
+
+    collection = lxb_dom_collection_make(&document->dom_document, 16);
+    test_ne(collection, NULL);
+
+    // ID
+    status = lxb_dom_elements_by_attr(lxb_dom_interface_element(document),
+                                      collection,
+                                      (lxb_char_t *) "id", 2,
+                                      (lxb_char_t *) "abc", 3, false);
+    test_eq(status, LXB_STATUS_OK);
+    test_eq(lxb_dom_collection_length(collection), 1);
+
+    // Empty ID
+    status = lxb_dom_elements_by_attr(lxb_dom_interface_element(document),
+                                      collection,
+                                      (lxb_char_t *) "id", 2,
+                                      (lxb_char_t *) "", 0, false);
+    test_eq(status, LXB_STATUS_OK);
+    test_eq(lxb_dom_collection_length(collection), 3);
+
+    // Arbitrary attribute name
+    status = lxb_dom_elements_by_attr(lxb_dom_interface_element(document),
+                                      collection,
+                                      (lxb_char_t *) "foo", 3,
+                                      (lxb_char_t *) "abc", 3, false);
+    test_eq(status, LXB_STATUS_OK);
+    test_eq(lxb_dom_collection_length(collection), 4);
+
+    // Empty attribute
+    status = lxb_dom_elements_by_attr(lxb_dom_interface_element(document),
+                                      collection,
+                                      (lxb_char_t *) "foo", 3,
+                                      (lxb_char_t *) "", 0, false);
+    test_eq(status, LXB_STATUS_OK);
+    test_eq(lxb_dom_collection_length(collection), 6);
+
+    // Empty attribute with NULL
+    status = lxb_dom_elements_by_attr(lxb_dom_interface_element(document),
+                                      collection,
+                                      (lxb_char_t *) "foo", 3,
+                                      (lxb_char_t *) NULL, 0, false);
+    test_eq(status, LXB_STATUS_OK);
     test_eq(lxb_dom_collection_length(collection), 8);
 
     lxb_dom_collection_destroy(collection, true);
@@ -60,6 +140,7 @@ main(int argc, const char * argv[])
     TEST_INIT();
 
     TEST_ADD(by_class);
+    TEST_ADD(by_attr);
 
     TEST_RUN("lexbor/html/element_by");
     TEST_RELEASE();

--- a/test/lexbor/selectors/selectors.c
+++ b/test/lexbor/selectors/selectors.c
@@ -43,7 +43,8 @@ static const lxb_char_t html[] =
     "    <span test span=11></span>"
     "    <span test='' span=12></span>"
     "</p>"
-    "</div>";
+    "</div>"
+    "<div id class foo></div>";
 
 
 static const lxb_test_entry_t selectors_list[] =
@@ -202,7 +203,8 @@ static const lxb_test_entry_t selectors_list[] =
      "<a a=\"8\">\n"
      "<span span=\"10\">\n"
      "<span test span=\"11\">\n"
-     "<span test=\"\" span=\"12\">"},
+     "<span test=\"\" span=\"12\">\n"
+     "<div id class foo>"},
 
     {"div span",
      "<span id=\"s1\" span=\"1\">\n"
@@ -365,6 +367,40 @@ static const lxb_test_entry_t selectors_list[] =
      "<p p=\"4\">\n"
      "<p p=\"5\">\n"
      "<p p=\"7\" lang=\"ru\">"},
+
+    {".non-existent-class",
+     ""},
+
+    {"[class]",
+     "<div div=\"First\" class=\"Strong Massive\">\n"
+     "<div div=\"Second\" class=\"Massive Stupid\">\n"
+     "<div id class foo>"},
+
+    {"[class = \"\"]",
+     "<div id class foo>"},
+
+    {"#non-existent-id",
+     ""},
+
+    {"[id]",
+     "<span id=\"s1\" span=\"1\">\n"
+     "<span id=\"s2\" span=\"2\">\n"
+     "<span id=\"s3\" span=\"3\">\n"
+     "<span id=\"s4\" span=\"4\">\n"
+     "<span id=\"s5\" span=\"5\">\n"
+     "<div id class foo>"},
+
+    {"[id = \"\"]",
+     "<div id class foo>"},
+
+    {"[non-existent-attr]",
+     ""},
+
+    {"div[foo]",
+     "<div id class foo>"},
+
+    {"[foo = \"a\"]",
+     ""}
 };
 
 


### PR DESCRIPTION
There were multiple situations in which Lexbor would crash when a selected attribute had either no value or an empty value was given to the match function.

This PR prevents the following crashes:

- Matching of class names or attributes with `lxb_dom_elements_by_class_name()` or `lxb_dom_elements_by_attr()` when the document contains elements with `NULL`-valued attributes
- CSS class, ID, or attribute selectors when the document contains elements with `NULL`-valued attributes
- `lxb_dom_elements_by_class_name()` and `lxb_dom_elements_by_attr()` when given an empty (non-`NULL`, but zero-length) or `NULL` value for comparison

If you pass an empty/`NULL` value to `lxb_dom_elements_by_class_name()`, it won't match anything, but at least it doesn't crash anymore. `lxb_dom_elements_by_attr()` will match attributes with either empty or `NULL` values.

Fixes #145

Tests were added.