### PR TITLE
Fix heap use after free crash, resolves #156

### DIFF
--- a/source/lexbor/html/tokenizer/state.c
+++ b/source/lexbor/html/tokenizer/state.c
@@ -1872,9 +1872,10 @@ done:
 
     if (tail_size != 0) {
         if ((size + tail_size) + start > tkz->end) {
-            if(lxb_html_tokenizer_temp_realloc(tkz, size)) {
+            if (lxb_html_tokenizer_temp_realloc(tkz, size) != LXB_STATUS_OK) {
                 return end;
             }
+            start = &tkz->start[tkz->entity_start];
         }
 
         memmove(start + tkz->entity_match->value_len,


### PR DESCRIPTION
Fixes a heap use after free crash after a call to `lxb_html_tokenizer_temp_realloc()`.

The cause of the crash wasn't easy to find, but I was able to track it down eventually with ASAN and the example document that I attached to the original issue report.
I wanted to add a synthetic test case to catch this error in the future, but I wasn't able to find an example that triggers the tokenizer buffer reallocation except the example file posted to the original issue (mostly because I don't really understand what the function is doing).

Fixes #156