### PR TITLE
Fix null pointer exception

### DIFF
--- a/source/lexbor/selectors/selectors.c
+++ b/source/lexbor/selectors/selectors.c
@@ -262,7 +262,7 @@ lxb_selectors_sibling(lxb_selectors_t *selectors, lxb_selectors_entry_t *entry,
 {
     node = node->next;
 
-    do {
+    while (node != NULL) {
         if (node->type == LXB_DOM_NODE_TYPE_ELEMENT) {
             if (lxb_selectors_match(selectors, entry, selector, node)) {
                 return node;
@@ -273,7 +273,6 @@ lxb_selectors_sibling(lxb_selectors_t *selectors, lxb_selectors_entry_t *entry,
 
         node = node->next;
     }
-    while (node != NULL);
 
     return NULL;
 }


### PR DESCRIPTION
This change fixes access violation if next is null. The other similar functions check for the same null condition exactly like this anyway. Note that this issue really happens causing my application to crash, the location in the sources I have determined using WinDbg.