### PR TITLE
Support overriding default memory functions

### DIFF
--- a/source/lexbor/core/lexbor.h
+++ b/source/lexbor/core/lexbor.h
@@ -13,10 +13,10 @@ extern "C" {
 
 #include "lexbor/core/def.h"
 
-typedef void *(*lexbor_malloc_f)(size_t size);
-typedef void *(*lexbor_realloc_f)(void *dst, size_t size);
-typedef void *(*lexbor_calloc_f)(size_t num, size_t size);
-typedef void (*lexbor_free_f)(void *dst);
+typedef void *(*lexbor_memory_malloc_f)(size_t size);
+typedef void *(*lexbor_memory_realloc_f)(void *dst, size_t size);
+typedef void *(*lexbor_memory_calloc_f)(size_t num, size_t size);
+typedef void (*lexbor_memory_free_f)(void *dst);
 
 LXB_API void *
 lexbor_malloc(size_t size);
@@ -31,8 +31,8 @@ LXB_API void *
 lexbor_free(void *dst);
 
 LXB_API lxb_status_t
-lexbor_memory_setup(lexbor_malloc_f malloc_f, lexbor_realloc_f realloc_f,
-                    lexbor_calloc_f calloc_f, lexbor_free_f free_f);
+lexbor_memory_setup(lexbor_memory_malloc_f new_malloc, lexbor_memory_realloc_f new_realloc,
+                    lexbor_memory_calloc_f new_calloc, lexbor_memory_free_f new_free);
 
 
 #ifdef __cplusplus

--- a/source/lexbor/core/lexbor.h
+++ b/source/lexbor/core/lexbor.h
@@ -13,6 +13,10 @@ extern "C" {
 
 #include "lexbor/core/def.h"
 
+typedef void *(*lexbor_malloc_f)(size_t size);
+typedef void *(*lexbor_realloc_f)(void *dst, size_t size);
+typedef void *(*lexbor_calloc_f)(size_t num, size_t size);
+typedef void (*lexbor_free_f)(void *dst);
 
 LXB_API void *
 lexbor_malloc(size_t size);
@@ -25,6 +29,10 @@ lexbor_calloc(size_t num, size_t size);
 
 LXB_API void *
 lexbor_free(void *dst);
+
+LXB_API lxb_status_t
+lexbor_memory_setup(lexbor_malloc_f malloc_f, lexbor_realloc_f realloc_f,
+                    lexbor_calloc_f calloc_f, lexbor_free_f free_f);
 
 
 #ifdef __cplusplus

--- a/source/lexbor/ports/posix/lexbor/core/memory.c
+++ b/source/lexbor/ports/posix/lexbor/core/memory.c
@@ -6,46 +6,48 @@
 
 #include "lexbor/core/base.h"
 
-static lexbor_malloc_f malloc_f = malloc;
-static lexbor_realloc_f realloc_f = realloc;
-static lexbor_calloc_f calloc_f = calloc;
-static lexbor_free_f free_f = free;
+static lexbor_memory_malloc_f lexbor_memory_malloc = malloc;
+static lexbor_memory_realloc_f lexbor_memory_realloc = realloc;
+static lexbor_memory_calloc_f lexbor_memory_calloc = calloc;
+static lexbor_memory_free_f lexbor_memory_free = free;
 
 void *
 lexbor_malloc(size_t size)
 {
-    return malloc_f(size);
+    return lexbor_memory_malloc(size);
 }
 
 void *
 lexbor_realloc(void *dst, size_t size)
 {
-    return realloc_f(dst, size);
+    return lexbor_memory_realloc(dst, size);
 }
 
 void *
 lexbor_calloc(size_t num, size_t size)
 {
-    return calloc_f(num, size);
+    return lexbor_memory_calloc(num, size);
 }
 
 void *
 lexbor_free(void *dst)
 {
-    free_f(dst);
+    lexbor_memory_free(dst);
     return NULL;
 }
 
 lxb_status_t
-lexbor_memory_setup(lexbor_malloc_f _malloc_f, lexbor_realloc_f _realloc_f,
-                    lexbor_calloc_f _calloc_f, lexbor_free_f _free_f)
+lexbor_memory_setup(lexbor_memory_malloc_f new_malloc, lexbor_memory_realloc_f new_realloc,
+                    lexbor_memory_calloc_f new_calloc, lexbor_memory_free_f new_free)
 {
-    if (_malloc_f == NULL || _realloc_f == NULL || _calloc_f == NULL || _free_f == NULL) {
+    if (new_malloc == NULL || new_realloc == NULL || new_calloc == NULL || new_free == NULL) {
         return LXB_STATUS_ERROR_OBJECT_IS_NULL;
     }
-    malloc_f = _malloc_f;
-    realloc_f = _realloc_f;
-    calloc_f = _calloc_f;
-    free_f = _free_f;
+
+    lexbor_memory_malloc = new_malloc;
+    lexbor_memory_realloc = new_realloc;
+    lexbor_memory_calloc = new_calloc;
+    lexbor_memory_free = new_free;
+
     return LXB_STATUS_OK;
 }

--- a/source/lexbor/ports/posix/lexbor/core/memory.c
+++ b/source/lexbor/ports/posix/lexbor/core/memory.c
@@ -6,28 +6,46 @@
 
 #include "lexbor/core/base.h"
 
+static lexbor_malloc_f malloc_f = malloc;
+static lexbor_realloc_f realloc_f = realloc;
+static lexbor_calloc_f calloc_f = calloc;
+static lexbor_free_f free_f = free;
 
 void *
 lexbor_malloc(size_t size)
 {
-    return malloc(size);
+    return malloc_f(size);
 }
 
 void *
 lexbor_realloc(void *dst, size_t size)
 {
-    return realloc(dst, size);
+    return realloc_f(dst, size);
 }
 
 void *
 lexbor_calloc(size_t num, size_t size)
 {
-    return calloc(num, size);
+    return calloc_f(num, size);
 }
 
 void *
 lexbor_free(void *dst)
 {
-    free(dst);
+    free_f(dst);
     return NULL;
+}
+
+lxb_status_t
+lexbor_memory_setup(lexbor_malloc_f _malloc_f, lexbor_realloc_f _realloc_f,
+                    lexbor_calloc_f _calloc_f, lexbor_free_f _free_f)
+{
+    if (_malloc_f == NULL || _realloc_f == NULL || _calloc_f == NULL || _free_f == NULL) {
+        return LXB_STATUS_ERROR_OBJECT_IS_NULL;
+    }
+    malloc_f = _malloc_f;
+    realloc_f = _realloc_f;
+    calloc_f = _calloc_f;
+    free_f = _free_f;
+    return LXB_STATUS_OK;
 }

--- a/source/lexbor/ports/windows_nt/lexbor/core/memory.c
+++ b/source/lexbor/ports/windows_nt/lexbor/core/memory.c
@@ -6,46 +6,48 @@
 
 #include "lexbor/core/base.h"
 
-static lexbor_malloc_f malloc_f = malloc;
-static lexbor_realloc_f realloc_f = realloc;
-static lexbor_calloc_f calloc_f = calloc;
-static lexbor_free_f free_f = free;
+static lexbor_memory_malloc_f lexbor_memory_malloc = malloc;
+static lexbor_memory_realloc_f lexbor_memory_realloc = realloc;
+static lexbor_memory_calloc_f lexbor_memory_calloc = calloc;
+static lexbor_memory_free_f lexbor_memory_free = free;
 
 void *
 lexbor_malloc(size_t size)
 {
-    return malloc_f(size);
+    return lexbor_memory_malloc(size);
 }
 
 void *
 lexbor_realloc(void *dst, size_t size)
 {
-    return realloc_f(dst, size);
+    return lexbor_memory_realloc(dst, size);
 }
 
 void *
 lexbor_calloc(size_t num, size_t size)
 {
-    return calloc_f(num, size);
+    return lexbor_memory_calloc(num, size);
 }
 
 void *
 lexbor_free(void *dst)
 {
-    free_f(dst);
+    lexbor_memory_free(dst);
     return NULL;
 }
 
 lxb_status_t
-lexbor_memory_setup(lexbor_malloc_f _malloc_f, lexbor_realloc_f _realloc_f,
-                    lexbor_calloc_f _calloc_f, lexbor_free_f _free_f)
+lexbor_memory_setup(lexbor_memory_malloc_f new_malloc, lexbor_memory_realloc_f new_realloc,
+                    lexbor_memory_calloc_f new_calloc, lexbor_memory_free_f new_free)
 {
-    if (_malloc_f == NULL || _realloc_f == NULL || _calloc_f == NULL || _free_f == NULL) {
+    if (new_malloc == NULL || new_realloc == NULL || new_calloc == NULL || new_free == NULL) {
         return LXB_STATUS_ERROR_OBJECT_IS_NULL;
     }
-    malloc_f = _malloc_f;
-    realloc_f = _realloc_f;
-    calloc_f = _calloc_f;
-    free_f = _free_f;
+
+    lexbor_memory_malloc = new_malloc;
+    lexbor_memory_realloc = new_realloc;
+    lexbor_memory_calloc = new_calloc;
+    lexbor_memory_free = new_free;
+
     return LXB_STATUS_OK;
 }

--- a/source/lexbor/ports/windows_nt/lexbor/core/memory.c
+++ b/source/lexbor/ports/windows_nt/lexbor/core/memory.c
@@ -6,28 +6,46 @@
 
 #include "lexbor/core/base.h"
 
+static lexbor_malloc_f malloc_f = malloc;
+static lexbor_realloc_f realloc_f = realloc;
+static lexbor_calloc_f calloc_f = calloc;
+static lexbor_free_f free_f = free;
 
 void *
 lexbor_malloc(size_t size)
 {
-    return malloc(size);
+    return malloc_f(size);
 }
 
 void *
 lexbor_realloc(void *dst, size_t size)
 {
-    return realloc(dst, size);
+    return realloc_f(dst, size);
 }
 
 void *
 lexbor_calloc(size_t num, size_t size)
 {
-    return calloc(num, size);
+    return calloc_f(num, size);
 }
 
 void *
 lexbor_free(void *dst)
 {
-    free(dst);
+    free_f(dst);
     return NULL;
+}
+
+lxb_status_t
+lexbor_memory_setup(lexbor_malloc_f _malloc_f, lexbor_realloc_f _realloc_f,
+                    lexbor_calloc_f _calloc_f, lexbor_free_f _free_f)
+{
+    if (_malloc_f == NULL || _realloc_f == NULL || _calloc_f == NULL || _free_f == NULL) {
+        return LXB_STATUS_ERROR_OBJECT_IS_NULL;
+    }
+    malloc_f = _malloc_f;
+    realloc_f = _realloc_f;
+    calloc_f = _calloc_f;
+    free_f = _free_f;
+    return LXB_STATUS_OK;
 }


### PR DESCRIPTION
When developing [Nokolexbor](https://github.com/serpapi/nokolexbor), I needed to use ruby-specific memory functions `ruby_xmalloc`, `ruby_xrealloc`, `ruby_xcalloc` and `ruby_xfree` instead of `malloc`, `realloc`, `calloc` and `free` to make it work well with ruby GC behavior.

A setup function similar to [xmlMemSetup](https://github.com/GNOME/libxml2/blob/a77e32736c63bbb26714f9565d9ce74cf48f169d/xmlmemory.c#L951) will be handy so that users can override default memory functions.

```
lexbor_memory_setup(ruby_xmalloc, ruby_xrealloc, ruby_xcalloc, ruby_xfree);
```

Not sure if naming corresponds to Lexbor conventions.

---

_A side question:_
Since `memory.c` are identical in `posix/lexbor/core` and `windows_nt/lexbor/core`, can we move it out?