### PR TITLE
Fix "comparison is always true due to limited range of data type" warning

### DIFF
--- a/source/lexbor/css/syntax/state.c
+++ b/source/lexbor/css/syntax/state.c
@@ -2530,7 +2530,7 @@ lxb_css_syntax_state_url(lxb_css_syntax_tokenizer_t *tkz, lxb_css_syntax_token_t
                  * U+0000 NULL and U+0008 BACKSPACE or
                  * U+000E SHIFT OUT and U+001F INFORMATION SEPARATOR ONE
                  */
-                if ((*data >= 0x00 && *data <= 0x08)
+                if ((*data <= 0x08)
                     || (*data >= 0x0E && *data <= 0x1F))
                 {
                     lxb_css_syntax_tokenizer_error_add(tkz->parse_errors, data,


### PR DESCRIPTION
lxb_char_t is defined as unsigned char. Therefore `*data >= 0x00` is always true. This causes compiler warnings and a compilation failure if -werror is enabled.