### PR TITLE
Add token location information to lxb_html_tree_error_t

### DIFF
--- a/source/lexbor/html/tree/error.c
+++ b/source/lexbor/html/tree/error.c
@@ -21,6 +21,8 @@ lxb_html_tree_error_add(lexbor_array_obj_t *parse_errors,
     }
 
     entry->id = id;
+    entry->token_begin = token->begin;
+    entry->token_end = token->end;
 
     return entry;
 }

--- a/source/lexbor/html/tree/error.c
+++ b/source/lexbor/html/tree/error.c
@@ -21,8 +21,8 @@ lxb_html_tree_error_add(lexbor_array_obj_t *parse_errors,
     }
 
     entry->id = id;
-    entry->token_begin = token->begin;
-    entry->token_end = token->end;
+    entry->begin = token->begin;
+    entry->end = token->end;
 
     return entry;
 }

--- a/source/lexbor/html/tree/error.h
+++ b/source/lexbor/html/tree/error.h
@@ -97,8 +97,8 @@ lxb_html_tree_error_id_t;
 
 typedef struct {
     lxb_html_tree_error_id_t id;
-    const lxb_char_t *token_begin;
-    const lxb_char_t *token_end;
+    const lxb_char_t         *begin;
+    const lxb_char_t         *end;
 }
 lxb_html_tree_error_t;
 

--- a/source/lexbor/html/tree/error.h
+++ b/source/lexbor/html/tree/error.h
@@ -97,6 +97,8 @@ lxb_html_tree_error_id_t;
 
 typedef struct {
     lxb_html_tree_error_id_t id;
+    const lxb_char_t *token_begin;
+    const lxb_char_t *token_end;
 }
 lxb_html_tree_error_t;
 


### PR DESCRIPTION
This is necessary for error-reporting in our use-case.

Also a question:
Is there a builtin function in lexbor to convert an offset to a line+column number?
I can do it manually of course by looping over the input and counting the number of newlines.