### PR TITLE
Core: Fix test failure on 32-bit architectures

### DIFF
--- a/test/lexbor/core/hash.c
+++ b/test/lexbor/core/hash.c
@@ -10,6 +10,8 @@
 
 
 typedef struct {
+    lexbor_hash_entry_t entry;
+
     lexbor_hash_t hash;
     size_t        value;
 }


### PR DESCRIPTION
On 32-bit architectures, the `lexbor_core_hash` test can segfault. This has been reported in 2022 in #153. The root cause of the issue is that the hash map implementation assumes that the hash map entry type is at least large enough to store a `lexbor_hash_entry_t` type. This is never explicitly documented anywhere, but the following allocation illustrates this implicit assumption:

https://github.com/lexbor/lexbor/blob/743353b511bd554daf50c9e08945ee6790333157/source/lexbor/core/hash.c#L98

The `hash->entries` members corresponds to the `struct_size` specified during `lexbor_hash_init`. Regarding `struct_size` the following assumption must hold for the code above to make some sense:

```C
struct_size >= sizeof(lexbor_hash_entry_t)
```

For the `hash_entry_t` from `test/lexbor/core/hash.c` this assumption does not necessarily hold as, contrary to other hash structures defined in the source, this struct doesn't include a `lexbor_hash_entry_t` member. See for example:

https://github.com/lexbor/lexbor/blob/743353b511bd554daf50c9e08945ee6790333157/source/lexbor/ns/ns.h#L20-L27

or:

https://github.com/lexbor/lexbor/blob/743353b511bd554daf50c9e08945ee6790333157/source/lexbor/tag/tag.h#L22-L28

This commit fixes this by adding a `lexbor_hash_entry_t` member to `hash_entry_t`.

Fixes #153