### PR TITLE
Remove redundant double assign in lxb_html_tree_insertion_mode_in_body_textarea()

### DIFF
--- a/source/lexbor/html/tree/insertion_mode/in_body.c
+++ b/source/lexbor/html/tree/insertion_mode/in_body.c
@@ -1320,8 +1320,6 @@ lxb_html_tree_insertion_mode_in_body_textarea(lxb_html_tree_t *tree,
     lxb_html_tokenizer_state_set(tree->tkz_ref,
                                  lxb_html_tokenizer_state_rcdata_before);
 
-    tree->original_mode = tree->mode;
-
     tree->frameset_ok = false;
 
     tree->original_mode = tree->mode;


### PR DESCRIPTION
tree->original_mode is already set to tree->mode a few lines further down.