### PR TITLE
Fix potential NULL pointer dereference

### DIFF
--- a/source/lexbor/selectors/selectors.c
+++ b/source/lexbor/selectors/selectors.c
@@ -344,6 +344,10 @@ lxb_selectors_state_tree(lxb_selectors_t *selectors, lxb_dom_node_t *root,
         node = root->first_child;
     }
 
+    if (node == NULL) {
+        goto out;
+    }
+
     do {
         if (node->type != LXB_DOM_NODE_TYPE_ELEMENT) {
             goto next;
@@ -380,6 +384,7 @@ lxb_selectors_state_tree(lxb_selectors_t *selectors, lxb_dom_node_t *root,
     }
     while (true);
 
+out:
     lxb_selectors_clean(selectors);
 
     return LXB_STATUS_OK;


### PR DESCRIPTION
`first_child` can be NULL, for example when you pass an element created by createElement as the scope's root and don't add children. If it is NULL, the NULL dereference will take place when checking if `node` is of type element.

I don't have an isolated test case at hand; I discovered this while writing tests for the integration of Lexbor's CSS selectors into PHP.

The PHP test looks something like this:
```php
$document->createElement("childless")->querySelectorAll(':root');
```