### PR TITLE
Improve performance of certain tokenizer states using SWAR

### DIFF
--- a/source/lexbor/core/swar.h
+++ b/source/lexbor/core/swar.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Alexander Borisov
+ *
+ * Author: Niels Dossche <nielsdos@php.net>
+ */
+
+#ifndef LEXBOR_SWAR_H
+#define LEXBOR_SWAR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#include "lexbor/core/base.h"
+
+
+/* Based on techniques from https://graphics.stanford.edu/~seander/bithacks.html */
+#define SWAR_ONES (~((size_t) 0) / 0xFF)
+#define SWAR_REPEAT(x) (SWAR_ONES * (x))
+#define SWAR_HAS_ZERO(v) (((v) - SWAR_ONES) & ~(v) & SWAR_REPEAT(0x80))
+#define SWAR_IS_LITTLE_ENDIAN (*(unsigned char *)&(uint16_t){1})
+
+
+/* When handling hot loops that search for a set of characters,
+ * this function can be used to quickly move the data pointer much
+ * closer to the first occurrence of such a character. */
+lxb_inline const lxb_char_t *lxb_swar_seek4(const lxb_char_t *data,
+                                            const lxb_char_t *end,
+                                            lxb_char_t c1, lxb_char_t c2,
+                                            lxb_char_t c3, lxb_char_t c4)
+{
+    if (SWAR_IS_LITTLE_ENDIAN) {
+        while (data + sizeof(size_t) <= end) {
+            size_t bytes;
+            memcpy(&bytes, data, sizeof(size_t));
+
+            size_t t1 = bytes ^ SWAR_REPEAT(c1);
+            size_t t2 = bytes ^ SWAR_REPEAT(c2);
+            size_t t3 = bytes ^ SWAR_REPEAT(c3);
+            size_t t4 = bytes ^ SWAR_REPEAT(c4);
+            size_t matches = SWAR_HAS_ZERO(t1) | SWAR_HAS_ZERO(t2)
+                           | SWAR_HAS_ZERO(t3) | SWAR_HAS_ZERO(t4);
+
+            if (matches) {
+                data += ((((matches - 1) & SWAR_ONES) * SWAR_ONES)
+                        >> (sizeof(size_t) * 8 - 8)) - 1;
+                break;
+            } else {
+                data += sizeof(size_t);
+            }
+        }
+    }
+
+    return data;
+}
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* LEXBOR_SWAR_H */
+

--- a/source/lexbor/html/tokenizer/state.c
+++ b/source/lexbor/html/tokenizer/state.c
@@ -15,6 +15,7 @@
 #define LEXBOR_STR_RES_MAP_HEX
 #define LEXBOR_STR_RES_MAP_NUM
 #include "lexbor/core/str_res.h"
+#include "lexbor/core/swar.h"
 
 #define LXB_HTML_TOKENIZER_RES_ENTITIES_SBST
 #include "lexbor/html/tokenizer/res.h"
@@ -225,6 +226,8 @@ lxb_html_tokenizer_state_data(lxb_html_tokenizer_t *tkz,
                               const lxb_char_t *data, const lxb_char_t *end)
 {
     lxb_html_tokenizer_state_begin_set(tkz, data);
+
+    data = lxb_swar_seek4(data, end, 0x3C, 0x26, 0x0D, 0x00);
 
     while (data != end) {
         switch (*data) {
@@ -905,6 +908,8 @@ lxb_html_tokenizer_state_attribute_value_double_quoted(lxb_html_tokenizer_t *tkz
     }
 
     lxb_html_tokenizer_state_begin_set(tkz, data);
+
+    data = lxb_swar_seek4(data, end, 0x22, 0x26, 0x0D, 0x00);
 
     while (data != end) {
         switch (*data) {


### PR DESCRIPTION
While profiling I noticed that the attribute_value_double_quoted state and data state were very hot in the profile. This patch implements a generic SWAR routine to seek towards an occurrence of any 4 characters in steps of 4/8 bytes at once (depending on the bit width of the CPU).

I benchmarked this on an i7-4790 (32 GiB RAM) using this script: https://gist.github.com/nielsdos/fbbcfb404fdee92e6c814212de81d015 A limited benchmark shows the following:

|                            | baseline            | double_quotes       | double_quotes + state_data |
|----------------------------|---------------------|---------------------|----------------------------|
| StackOverflow homepage     | 329.6 ms ±   3.4 ms | 288.2 ms ±   3.5 ms | 281.0 ms ±   4.6 ms        |
| English Wikipedia homepage | 289.0 ms ±   2.5 ms | 283.5 ms ±   4.5 ms | 275.9 ms ±   4.3 ms        |
| GitHub "For You" page      | 623.2 ms ±   8.0 ms | 570.1 ms ±   4.1 ms | 559.2 ms ±   4.9 ms        |

The baseline was computed on commit e9d35f6384de7bd8c1b79e7111bc3a44f8822967. The double_quotes test was applying SWAR to only the double_quotes state and the last column applies SWAR both for double_quotes and the data state.

As I don't have a dataset, I only tested this on 3 pages.
If you have a benchmark dataset available please let me know so I can evaluate on that.
The limited benchmark shows there might be potential in these optimizations, but doesn't give a proper conclusion yet due to its small size (e.g. are there notable regressions on certain pages?)

I also experimented with using a bitmap instead of SWAR, but that didn't give much of a performance boost.
I also thought about using SSE2, but that's less generically applicable than SWAR and might start to run into a problem of setup overhead.