### PR TITLE
Remove useless assignment

### DIFF
--- a/source/lexbor/css/syntax/syntax.c
+++ b/source/lexbor/css/syntax/syntax.c
@@ -152,7 +152,6 @@ lxb_css_syntax_ident_serialize(const lxb_char_t *data, size_t length,
 
     static const lexbor_str_t str_s = lexbor_str("\\");
 
-    p = data;
     end = data + length;
     hex_map = lexbor_str_res_char_to_two_hex_value_lowercase;
 


### PR DESCRIPTION
p is already assigned at the declaration.