### PR TITLE
Remove unused arguments from tag by id lookup functions

### DIFF
--- a/examples/lexbor/html/element_create.c
+++ b/examples/lexbor/html/element_create.c
@@ -15,7 +15,6 @@ main(int argc, const char *argv[])
     lxb_html_document_t *document;
     lxb_dom_element_t *element;
     lxb_dom_text_t *text;
-    lexbor_hash_t *tags;
 
     const lxb_char_t *tag_name;
     size_t tag_name_len;
@@ -31,11 +30,9 @@ main(int argc, const char *argv[])
     printf("\n");
 
     /* Create all known tags */
-    tags = lxb_html_document_tags(document);
-
     for (tag_id = LXB_TAG_A; tag_id < LXB_TAG__LAST_ENTRY; tag_id++)
     {
-        tag_name = lxb_tag_name_by_id(tags, tag_id, &tag_name_len);
+        tag_name = lxb_tag_name_by_id(tag_id, &tag_name_len);
         if (tag_name == NULL) {
             FAILED("Failed to get tag name by id");
         }

--- a/examples/lexbor/html/tokenizer/callback.c
+++ b/examples/lexbor/html/tokenizer/callback.c
@@ -23,9 +23,8 @@ token_callback(lxb_html_tokenizer_t *tkz, lxb_html_token_t *token, void *ctx)
 {
     bool is_close;
     const lxb_char_t *name;
-    lexbor_hash_t *tags = lxb_html_tokenizer_tags(tkz);
 
-    name = lxb_tag_name_by_id(tags, token->tag_id, NULL);
+    name = lxb_tag_name_by_id(token->tag_id, NULL);
     if (name == NULL) {
         FAILED("Failed to get token name");
     }

--- a/examples/lexbor/html/tokenizer/tag_attributes.c
+++ b/examples/lexbor/html/tokenizer/tag_attributes.c
@@ -30,7 +30,7 @@ token_callback(lxb_html_tokenizer_t *tkz, lxb_html_token_t *token, void *ctx)
         return token;
     }
 
-    tag = lxb_tag_name_by_id(lxb_html_tokenizer_tags(tkz), token->tag_id, NULL);
+    tag = lxb_tag_name_by_id(token->tag_id, NULL);
     if (tag == NULL) {
         FAILED("Failed to get token name");
     }

--- a/source/lexbor/dom/interfaces/element.c
+++ b/source/lexbor/dom/interfaces/element.c
@@ -651,12 +651,10 @@ lxb_dom_element_qualified_name(lxb_dom_element_t *element, size_t *len)
     const lxb_tag_data_t *data;
 
     if (element->qualified_name != 0) {
-        data = lxb_tag_data_by_id(element->node.owner_document->tags,
-                                  element->qualified_name);
+        data = lxb_tag_data_by_id(element->qualified_name);
     }
     else {
-        data = lxb_tag_data_by_id(element->node.owner_document->tags,
-                                  element->node.local_name);
+        data = lxb_tag_data_by_id(element->node.local_name);
     }
 
     if (len != NULL) {
@@ -723,8 +721,7 @@ lxb_dom_element_local_name(lxb_dom_element_t *element, size_t *len)
 {
     const lxb_tag_data_t *data;
 
-    data = lxb_tag_data_by_id(element->node.owner_document->tags,
-                              element->node.local_name);
+    data = lxb_tag_data_by_id(element->node.local_name);
     if (data == NULL) {
         if (len != NULL) {
             *len = 0;

--- a/source/lexbor/dom/interfaces/node.c
+++ b/source/lexbor/dom/interfaces/node.c
@@ -184,7 +184,7 @@ lxb_dom_node_interface_copy(lxb_dom_node_t *dst,
             dst->local_name = src->local_name;
         }
         else {
-            tag = lxb_tag_data_by_id(from->tags, src->local_name);
+            tag = lxb_tag_data_by_id(src->local_name);
             if (tag == NULL) {
                 return LXB_STATUS_ERROR_NOT_EXISTS;
             }

--- a/source/lexbor/tag/tag.c
+++ b/source/lexbor/tag/tag.c
@@ -60,7 +60,7 @@ lxb_tag_append_lower(lexbor_hash_t *hash, const lxb_char_t *name, size_t length)
 }
 
 const lxb_tag_data_t *
-lxb_tag_data_by_id(lexbor_hash_t *hash, lxb_tag_id_t tag_id)
+lxb_tag_data_by_id(lxb_tag_id_t tag_id)
 {
     if (tag_id >= LXB_TAG__LAST_ENTRY) {
         if (tag_id == LXB_TAG__LAST_ENTRY) {
@@ -119,16 +119,15 @@ lxb_tag_data_by_name_upper(lexbor_hash_t *hash,
  * No inline functions for ABI.
  */
 const lxb_char_t *
-lxb_tag_name_by_id_noi(lexbor_hash_t *hash, lxb_tag_id_t tag_id, size_t *len)
+lxb_tag_name_by_id_noi(lxb_tag_id_t tag_id, size_t *len)
 {
-    return lxb_tag_name_by_id(hash, tag_id, len);
+    return lxb_tag_name_by_id(tag_id, len);
 }
 
 const lxb_char_t *
-lxb_tag_name_upper_by_id_noi(lexbor_hash_t *hash,
-                             lxb_tag_id_t tag_id, size_t *len)
+lxb_tag_name_upper_by_id_noi(lxb_tag_id_t tag_id, size_t *len)
 {
-    return lxb_tag_name_upper_by_id(hash, tag_id, len);
+    return lxb_tag_name_upper_by_id(tag_id, len);
 }
 
 lxb_tag_id_t

--- a/source/lexbor/tag/tag.h
+++ b/source/lexbor/tag/tag.h
@@ -29,7 +29,7 @@ lxb_tag_data_t;
 
 
 LXB_API const lxb_tag_data_t *
-lxb_tag_data_by_id(lexbor_hash_t *hash, lxb_tag_id_t tag_id);
+lxb_tag_data_by_id(lxb_tag_id_t tag_id);
 
 LXB_API const lxb_tag_data_t *
 lxb_tag_data_by_name(lexbor_hash_t *hash, const lxb_char_t *name, size_t len);
@@ -42,9 +42,9 @@ lxb_tag_data_by_name_upper(lexbor_hash_t *hash,
  * Inline functions
  */
 lxb_inline const lxb_char_t *
-lxb_tag_name_by_id(lexbor_hash_t *hash, lxb_tag_id_t tag_id, size_t *len)
+lxb_tag_name_by_id(lxb_tag_id_t tag_id, size_t *len)
 {
-    const lxb_tag_data_t *data = lxb_tag_data_by_id(hash, tag_id);
+    const lxb_tag_data_t *data = lxb_tag_data_by_id(tag_id);
     if (data == NULL) {
         if (len != NULL) {
             *len = 0;
@@ -61,9 +61,9 @@ lxb_tag_name_by_id(lexbor_hash_t *hash, lxb_tag_id_t tag_id, size_t *len)
 }
 
 lxb_inline const lxb_char_t *
-lxb_tag_name_upper_by_id(lexbor_hash_t *hash, lxb_tag_id_t tag_id, size_t *len)
+lxb_tag_name_upper_by_id(lxb_tag_id_t tag_id, size_t *len)
 {
-    const lxb_tag_data_t *data = lxb_tag_data_by_id(hash, tag_id);
+    const lxb_tag_data_t *data = lxb_tag_data_by_id(tag_id);
     if (data == NULL) {
         if (len != NULL) {
             *len = 0;
@@ -101,12 +101,10 @@ lxb_tag_mraw(lexbor_hash_t *hash)
  * No inline functions for ABI.
  */
 LXB_API const lxb_char_t *
-lxb_tag_name_by_id_noi(lexbor_hash_t *hash, lxb_tag_id_t tag_id,
-                       size_t *len);
+lxb_tag_name_by_id_noi(lxb_tag_id_t tag_id, size_t *len);
 
 LXB_API const lxb_char_t *
-lxb_tag_name_upper_by_id_noi(lexbor_hash_t *hash,
-                             lxb_tag_id_t tag_id, size_t *len);
+lxb_tag_name_upper_by_id_noi(lxb_tag_id_t tag_id, size_t *len);
 
 LXB_API lxb_tag_id_t
 lxb_tag_id_by_name_noi(lexbor_hash_t *hash,

--- a/test/lexbor/html/tags.c
+++ b/test/lexbor/html/tags.c
@@ -44,8 +44,7 @@ TEST_BEGIN(tags)
 
     test_eq(lxb_html_element_tag_id(element), LXB_TAG_DIV);
 
-    name = lxb_tag_name_by_id(lxb_html_document_tags(document),
-                              lxb_html_element_tag_id(element), &length);
+    name = lxb_tag_name_by_id(lxb_html_element_tag_id(element), &length);
     test_ne(name, NULL);
     test_eq_str(name, "div");
 
@@ -56,8 +55,7 @@ TEST_BEGIN(tags)
 
     test_gt(lxb_html_element_tag_id(element), LXB_TAG__LAST_ENTRY);
 
-    name = lxb_tag_name_by_id(lxb_html_document_tags(document),
-                              lxb_html_element_tag_id(element), &length);
+    name = lxb_tag_name_by_id(lxb_html_element_tag_id(element), &length);
     test_ne(name, NULL);
     test_eq_str(name, "hoho");
 

--- a/utils/lexbor/grammar/json.c
+++ b/utils/lexbor/grammar/json.c
@@ -335,8 +335,7 @@ lxb_grammar_json_ast_node_value(const lxb_grammar_node_t *node,
 
         case LXB_GRAMMAR_NODE_DECLARATION:
         case LXB_GRAMMAR_NODE_ELEMENT: {
-            tag_data = lxb_tag_data_by_id(node->u.node->owner_document->tags,
-                                          node->u.node->local_name);
+            tag_data = lxb_tag_data_by_id(node->u.node->local_name);
             if (tag_data == NULL) {
                 return LXB_STATUS_ERROR;
             }

--- a/utils/lexbor/grammar/node.c
+++ b/utils/lexbor/grammar/node.c
@@ -484,8 +484,7 @@ lxb_grammar_node_serialize(const lxb_grammar_node_t *node,
 
         case LXB_GRAMMAR_NODE_DECLARATION:
         case LXB_GRAMMAR_NODE_ELEMENT: {
-            tag_data = lxb_tag_data_by_id(node->u.node->owner_document->tags,
-                                          node->u.node->local_name);
+            tag_data = lxb_tag_data_by_id(node->u.node->local_name);
             if (tag_data == NULL) {
                 return LXB_STATUS_ERROR;
             }

--- a/utils/lexbor/grammar/test.c
+++ b/utils/lexbor/grammar/test.c
@@ -539,8 +539,7 @@ utils_lxb_grammar_test(const lxb_char_t *grammar, const size_t length,
     }
 
     while (declr != NULL) {
-        tag_data = lxb_tag_data_by_id(declr->u.node->owner_document->tags,
-                                      declr->u.node->local_name);
+        tag_data = lxb_tag_data_by_id(declr->u.node->local_name);
         if (tag_data == NULL) {
             status = LXB_STATUS_ERROR;
             goto done;


### PR DESCRIPTION
This removes unused hash arguments from tag by id lookup functions.

This does change the public API so I'm not sure if you want PRs like this.