### PR TITLE
Fix crash in python code tokenizer_entities_bst.py

### DIFF
--- a/utils/lexbor/html/tokenizer_entities_bst.py
+++ b/utils/lexbor/html/tokenizer_entities_bst.py
@@ -146,7 +146,7 @@ def toHex(s):
     lst = []
 
     for ch in bytes(s, 'utf-8'):
-        hv = hex(ch).replace('0x', '\\x')
+        hv = hex(ch).replace('0x', '\\\\x')
         lst.append(hv)
 
     return ''.join(lst)


### PR DESCRIPTION
I'm getting the following crash:
```
  File "lexbor/utils/lexbor/html/tokenizer_entities_bst.py", line 212, in <module>
    entities_bst("tmp/tokenizer_res.h",
  File "lexbor/utils/lexbor/html/tokenizer_entities_bst.py", line 20, in entities_bst
    lxb_temp.build()
  File "lexbor/utils/lexbor/html/../lexbor/LXB.py", line 30, in build
    line = re.sub(name, '\n'.join(self.patterns[name]), line)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 186, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 334, in _compile_template
    return _sre.template(pattern, _parser.parse_template(repl, pattern))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/_parser.py", line 1075, in parse_template
    raise s.error('bad escape %s' % this, len(this)) from None
re.error: bad escape \x at position 2336 (line 43, column 36)
```

Fix it by double escaping.