### PR TITLE
Add support for copying urls

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -4398,3 +4398,25 @@ lxb_url_serialize_fragment(const lxb_url_t *url,
 
     return LXB_STATUS_OK;
 }
+
+lxb_url_t *lxb_url_copy(lxb_url_parser_t *parser, lxb_url_t *url)
+{
+	lxb_url_t *new_url = lexbor_mraw_calloc(parser->mraw, sizeof(lxb_url_t));
+	if (new_url == NULL) {
+		return NULL;
+	}
+
+	new_url->mraw = parser->mraw;
+
+	lxb_url_scheme_copy(&url->scheme, &new_url->scheme, new_url->mraw);
+	lxb_url_username_copy(&url->username, &new_url->username, new_url->mraw);
+	lxb_url_password_copy(&url->password, &new_url->password, new_url->mraw);
+	lxb_url_host_copy(&url->host, &new_url->host, new_url->mraw);
+	new_url->port = url->port;
+	new_url->has_port = url->has_port;
+	lxb_url_path_copy(url, new_url);
+	lxb_url_query_copy(&url->query, &new_url->query, new_url->mraw);
+	lxb_url_str_copy(&url->fragment, &new_url->fragment, new_url->mraw);
+
+	return new_url;
+}

--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -4399,24 +4399,62 @@ lxb_url_serialize_fragment(const lxb_url_t *url,
     return LXB_STATUS_OK;
 }
 
-lxb_url_t *lxb_url_copy(lxb_url_parser_t *parser, lxb_url_t *url)
+lxb_url_t *
+lxb_url_clone(lexbor_mraw_t *mraw, lxb_url_t *url)
 {
-	lxb_url_t *new_url = lexbor_mraw_calloc(parser->mraw, sizeof(lxb_url_t));
+	lxb_status_t status;
+	lxb_url_t *new_url;
+
+	new_url = lexbor_mraw_calloc(mraw, sizeof(lxb_url_t));
 	if (new_url == NULL) {
 		return NULL;
 	}
 
-	new_url->mraw = parser->mraw;
+	new_url->mraw = mraw;
 
-	lxb_url_scheme_copy(&url->scheme, &new_url->scheme, new_url->mraw);
-	lxb_url_username_copy(&url->username, &new_url->username, new_url->mraw);
-	lxb_url_password_copy(&url->password, &new_url->password, new_url->mraw);
-	lxb_url_host_copy(&url->host, &new_url->host, new_url->mraw);
+	status = lxb_url_scheme_copy(&url->scheme, &new_url->scheme, mraw);
+	if (status != LXB_STATUS_OK) {
+		goto failed;
+	}
+
+	status = lxb_url_username_copy(&url->username, &new_url->username, mraw);
+	if (status != LXB_STATUS_OK) {
+		goto failed;
+	}
+
+	status = lxb_url_password_copy(&url->password, &new_url->password, mraw);
+	if (status != LXB_STATUS_OK) {
+		goto failed;
+	}
+
+	status = lxb_url_host_copy(&url->host, &new_url->host, mraw);
+	if (status != LXB_STATUS_OK) {
+		goto failed;
+	}
+
 	new_url->port = url->port;
 	new_url->has_port = url->has_port;
-	lxb_url_path_copy(url, new_url);
-	lxb_url_query_copy(&url->query, &new_url->query, new_url->mraw);
-	lxb_url_str_copy(&url->fragment, &new_url->fragment, new_url->mraw);
+
+	status = lxb_url_path_copy(url, new_url);
+	if (status != LXB_STATUS_OK) {
+		goto failed;
+	}
+
+	status = lxb_url_query_copy(&url->query, &new_url->query, mraw);
+	if (status != LXB_STATUS_OK) {
+		goto failed;
+	}
+
+	status = lxb_url_str_copy(&url->fragment, &new_url->fragment, mraw);
+	if (status != LXB_STATUS_OK) {
+		goto failed;
+	}
 
 	return new_url;
+
+failed:
+
+	lxb_url_destroy(new_url);
+
+	return NULL;
 }

--- a/source/lexbor/url/url.h
+++ b/source/lexbor/url/url.h
@@ -371,7 +371,18 @@ LXB_API lxb_status_t
 lxb_url_serialize_fragment(const lxb_url_t *url,
                            lexbor_serialize_cb_f cb, void *ctx);
 
-lxb_url_t *lxb_url_copy(lxb_url_parser_t *parser, lxb_url_t *url);
+/*
+ * Creates a clone of the object's URL.
+ *
+ * For lexbor_mraw_t *, use url->mraw or another lexbor_mraw_t * object.
+ *
+ * @param[in] lexbor_mraw_t *.
+ * @param[in] lxb_url_t *.
+ *
+ * @return a new URL object if successful, otherwise NULL value.
+ */
+LXB_API lxb_url_t *
+lxb_url_clone(lexbor_mraw_t *mraw, lxb_url_t *url);
 
 /*
  * Inline functions.

--- a/source/lexbor/url/url.h
+++ b/source/lexbor/url/url.h
@@ -371,6 +371,7 @@ LXB_API lxb_status_t
 lxb_url_serialize_fragment(const lxb_url_t *url,
                            lexbor_serialize_cb_f cb, void *ctx);
 
+lxb_url_t *lxb_url_copy(lxb_url_parser_t *parser, lxb_url_t *url);
 
 /*
  * Inline functions.


### PR DESCRIPTION
I intend to use the new function for adding support for cloning the URL objects in the PHP binding.

This will become especially important once Lexbor supports modification of URL components, because then it will be possible to use "wither" methods in PHP: we create a new Uri instance for every property change, leaving the original instance unaffected (thus reaching immutability).