### PR TITLE
Fix typo in state_res.h

### DIFF
--- a/source/lexbor/css/syntax/state_res.h
+++ b/source/lexbor/css/syntax/state_res.h
@@ -49,7 +49,7 @@ lxb_css_syntax_state_res_map[256] =
     lxb_css_syntax_state_hash, /* 0x23; '#'; Pound sign */
     lxb_css_syntax_state_delim, /* 0x24; '$'; Dollar sign */
     lxb_css_syntax_state_delim, /* 0x25; '%'; Percentage sign */
-    lxb_css_syntax_state_delim, /* 0x26; '&'; Commericial and */
+    lxb_css_syntax_state_delim, /* 0x26; '&'; Ampersand */
     lxb_css_syntax_state_string, /* 0x27; '''; Apostrophe */
     lxb_css_syntax_state_lparenthesis, /* 0x28; '('; Left bracket */
     lxb_css_syntax_state_rparenthesis, /* 0x29; ')'; Right bracket */


### PR DESCRIPTION
This PR fixes a typo first reported downstream via https://github.com/php/php-src/pull/17874#discussion_r1966581534