### PR TITLE
Fix for segmentation faults when using `:has` selectors, in some circumstances

### DIFF
--- a/source/lexbor/selectors/selectors.c
+++ b/source/lexbor/selectors/selectors.c
@@ -845,7 +845,7 @@ lxb_selectors_state_has_relative(lxb_dom_node_t *node,
             break;
         }
 
-        while (node !=root && node->next == NULL) {
+        while (node !=root && node->next == NULL && node->parent != NULL) {
             node = node->parent;
         }
 

--- a/test/lexbor/selectors/selectors.c
+++ b/test/lexbor/selectors/selectors.c
@@ -50,7 +50,7 @@ static const lxb_char_t html[] =
     "    <h2 h2=3 class=mark></h2>"
     "    <h2 h2=4 class=mark></h2>"
     "    <h2 h2=5></h2>"
-    "    <h2 h2=6 class=mark></h2>"
+    "    <h2 h2=6 class=mark></h2>\n"
     "</main>";
 
 
@@ -400,6 +400,10 @@ static const lxb_test_entry_t selectors_list[] =
     {"main > h2:nth-last-child(odd of .mark)",
      "<h2 h2=\"3\" class=\"mark\">\n"
      "<h2 h2=\"6\" class=\"mark\">"},
+
+    {"span:has(+ a)",
+     "<span span=\"6\">\n"
+     "<span span=\"9\">"}
 };
 
 


### PR DESCRIPTION
Hi @lexborisov,

First of all, thank you for this wonderful library ✨ !

I ran into a segmentation fault when using the `:has()` selector, due to a `node` being set to its `NULL` parent. It seems to depend on line-breaks/whitespace being present - though I don't think I've fully wrapped my head around what's going on.

My suggested fix (extending the guard statement to check if the parent is `NULL`) fixes the issue, although I'd appreciate a wiser mind as to whether the fix respects the desired logic. I've also added a test to catch the problematic case.

A minimal example to reproduce the segfault in the current version:

```c
#include <lexbor/html/html.h>
#include <lexbor/css/css.h>
#include <lexbor/selectors/selectors.h>

lxb_status_t
find_callback(lxb_dom_node_t *node, lxb_css_selector_specificity_t spec,
              void *ctx)
{
    return LXB_STATUS_OK;
}

int
main(int argc, const char *argv[])
{
    lxb_status_t status;
    lxb_dom_node_t *body;
    lxb_selectors_t *selectors;
    lxb_html_document_t *document;
    lxb_css_parser_t *parser;
    lxb_css_selector_list_t *list;

    static const lxb_char_t html[] = "<html><body><div></div>\n</body></html>";
    static const lxb_char_t slctrs[] = "a:has(+ b)";

    document = lxb_html_document_create();
    status = lxb_html_document_parse(document, html,
                                     sizeof(html) / sizeof(lxb_char_t) - 1);
    if (status != LXB_STATUS_OK) {
        return EXIT_FAILURE;
    }

    parser = lxb_css_parser_create();
    status = lxb_css_parser_init(parser, NULL);
    if (status != LXB_STATUS_OK) {
        return EXIT_FAILURE;
    }

    selectors = lxb_selectors_create();
    status = lxb_selectors_init(selectors);
    if (status != LXB_STATUS_OK) {
        return EXIT_FAILURE;
    }

    list = lxb_css_selectors_parse(parser, slctrs,
                                   sizeof(slctrs) / sizeof(lxb_char_t) - 1);
    if (parser->status != LXB_STATUS_OK) {
        return EXIT_FAILURE;
    }

    body = lxb_dom_interface_node(document);
    // Segfaults here
    status = lxb_selectors_find(selectors, body, list, find_callback, NULL);
    if (status != LXB_STATUS_OK) {
        return EXIT_FAILURE;
    }

    (void) lxb_selectors_destroy(selectors, true);
    (void) lxb_css_parser_destroy(parser, true);
    lxb_css_selector_list_destroy_memory(list);
    lxb_html_document_destroy(document);

    return EXIT_SUCCESS;
}
```