### PR TITLE
Fix misspelling of angle in CSS units

### DIFF
--- a/source/lexbor/css/property.c
+++ b/source/lexbor/css/property.c
@@ -1941,7 +1941,7 @@ lxb_css_property_font_style_serialize(const void *style,
         return status;
     }
 
-    if (fs->angle.unit != (lxb_css_unit_angel_t) LXB_CSS_UNIT__UNDEF) {
+    if (fs->angle.unit != (lxb_css_unit_angle_t) LXB_CSS_UNIT__UNDEF) {
         lexbor_serialize_write(cb, str_ws.data, str_ws.length, ctx, status);
 
         status = lxb_css_value_angle_sr(&fs->angle, cb, ctx);

--- a/source/lexbor/css/property/state.c
+++ b/source/lexbor/css/property/state.c
@@ -396,7 +396,7 @@ lxb_css_property_state_angle(lxb_css_parser_t *parser,
         return false;
     }
 
-    unit = lxb_css_unit_angel_by_name(lxb_css_syntax_token_dimension(token)->str.data,
+    unit = lxb_css_unit_angle_by_name(lxb_css_syntax_token_dimension(token)->str.data,
                                       lxb_css_syntax_token_dimension(token)->str.length);
     if (unit == NULL) {
         return false;
@@ -404,7 +404,7 @@ lxb_css_property_state_angle(lxb_css_parser_t *parser,
 
     angle->num = lxb_css_syntax_token_dimension(token)->num.num;
     angle->is_float = lxb_css_syntax_token_dimension(token)->num.is_float;
-    angle->unit = (lxb_css_unit_angel_t) unit->unique;
+    angle->unit = (lxb_css_unit_angle_t) unit->unique;
 
     lxb_css_syntax_parser_consume(parser);
 
@@ -450,7 +450,7 @@ lxb_css_property_state_hue(lxb_css_parser_t *parser,
 
     switch (token->type) {
         case LXB_CSS_SYNTAX_TOKEN_DIMENSION:
-            unit = lxb_css_unit_angel_by_name(lxb_css_syntax_token_dimension(token)->str.data,
+            unit = lxb_css_unit_angle_by_name(lxb_css_syntax_token_dimension(token)->str.data,
                                               lxb_css_syntax_token_dimension(token)->str.length);
             if (unit == NULL) {
                 return false;
@@ -459,7 +459,7 @@ lxb_css_property_state_hue(lxb_css_parser_t *parser,
             hue->type = LXB_CSS_VALUE__ANGLE;
             hue->u.angle.num = lxb_css_syntax_token_dimension(token)->num.num;
             hue->u.angle.is_float = lxb_css_syntax_token_dimension(token)->num.is_float;
-            hue->u.angle.unit = (lxb_css_unit_angel_t) unit->unique;
+            hue->u.angle.unit = (lxb_css_unit_angle_t) unit->unique;
             break;
 
         case LXB_CSS_SYNTAX_TOKEN_NUMBER:
@@ -3313,7 +3313,7 @@ lxb_css_property_state_font_style(lxb_css_parser_t *parser,
                 return lxb_css_parser_success(parser);
             }
             else {
-                fs->angle.unit = (lxb_css_unit_angel_t) LXB_CSS_UNIT__UNDEF;
+                fs->angle.unit = (lxb_css_unit_angle_t) LXB_CSS_UNIT__UNDEF;
             }
 
             break;

--- a/source/lexbor/css/unit.c
+++ b/source/lexbor/css/unit.c
@@ -51,11 +51,11 @@ lxb_css_unit_relative_by_name(const lxb_char_t *name, size_t length)
 }
 
 const lxb_css_data_t *
-lxb_css_unit_angel_by_name(const lxb_char_t *name, size_t length)
+lxb_css_unit_angle_by_name(const lxb_char_t *name, size_t length)
 {
     const lexbor_shs_entry_t *entry;
 
-    entry = lexbor_shs_entry_get_lower_static(lxb_css_unit_angel_shs,
+    entry = lexbor_shs_entry_get_lower_static(lxb_css_unit_angle_shs,
                                               name, length);
     if (entry == NULL) {
         return NULL;

--- a/source/lexbor/css/unit.h
+++ b/source/lexbor/css/unit.h
@@ -24,7 +24,7 @@ LXB_API const lxb_css_data_t *
 lxb_css_unit_relative_by_name(const lxb_char_t *name, size_t length);
 
 LXB_API const lxb_css_data_t *
-lxb_css_unit_angel_by_name(const lxb_char_t *name, size_t length);
+lxb_css_unit_angle_by_name(const lxb_char_t *name, size_t length);
 
 LXB_API const lxb_css_data_t *
 lxb_css_unit_frequency_by_name(const lxb_char_t *name, size_t length);

--- a/source/lexbor/css/unit/const.h
+++ b/source/lexbor/css/unit/const.h
@@ -58,14 +58,14 @@ typedef enum {
 lxb_css_unit_relative_t;
 
 typedef enum {
-    LXB_CSS_UNIT_ANGEL__BEGIN      = 0x0016,
+    LXB_CSS_UNIT_ANGLE__BEGIN      = 0x0016,
     LXB_CSS_UNIT_DEG               = 0x0016,
     LXB_CSS_UNIT_GRAD              = 0x0017,
     LXB_CSS_UNIT_RAD               = 0x0018,
     LXB_CSS_UNIT_TURN              = 0x0019,
-    LXB_CSS_UNIT_ANGEL__LAST_ENTRY = 0x001a
+    LXB_CSS_UNIT_ANGLE__LAST_ENTRY = 0x001a
 }
-lxb_css_unit_angel_t;
+lxb_css_unit_angle_t;
 
 typedef enum {
     LXB_CSS_UNIT_FREQUENCY__BEGIN      = 0x001a,

--- a/source/lexbor/css/unit/res.h
+++ b/source/lexbor/css/unit/res.h
@@ -246,7 +246,7 @@ static const lexbor_shs_entry_t lxb_css_unit_relative_shs[64] =
     {NULL, NULL, 0, 0}
 };
 
-static const lexbor_shs_entry_t lxb_css_unit_angel_shs[7] = 
+static const lexbor_shs_entry_t lxb_css_unit_angle_shs[7] = 
 {
     {NULL, NULL, 6, 0}, 
     {"turn", (void *) &lxb_css_unit_data[LXB_CSS_UNIT_TURN], 4, 0}, 

--- a/source/lexbor/css/value.h
+++ b/source/lexbor/css/value.h
@@ -109,7 +109,7 @@ lxb_css_value_length_percentage_type_t;
 typedef struct {
     double               num;
     bool                 is_float;
-    lxb_css_unit_angel_t unit;
+    lxb_css_unit_angle_t unit;
 }
 lxb_css_value_angle_t;
 

--- a/utils/lexbor/css/names.py
+++ b/utils/lexbor/css/names.py
@@ -274,7 +274,7 @@ unit_relative = {
     "vi": [], "vb": [], "vmin": [], "vmax": []
 }
 
-unit_angel = {
+unit_angle = {
     "deg": [],
     "grad": [],
     "rad": [],
@@ -296,7 +296,7 @@ unit_duration = {
 units = [
     ["absolute", unit_absolute],
     ["relative", unit_relative],
-    ["angel", unit_angel],
+    ["angel", unit_angle],
     ["frequency", unit_frequency],
     ["resolution", unit_resolution],
     ["duration", unit_duration]


### PR DESCRIPTION
Fixing some instances of `angle` being misspelled in the CSS code. Hopefully caught all of them.