### PR TITLE
fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ make
 make test
 ```
 
-Please, see more information in [documentation](https://lexbor.com/docs/lexbor/#source_code).
+Please, see more information in [documentation](https://lexbor.com/documentation/#source-code).
 
 ## Single or separately
 


### PR DESCRIPTION
The link seems to be broken.
I changed it to the correct link I probably think.