### PR TITLE
URL: Fix port setter for malformed ports

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -1906,7 +1906,7 @@ again:
             {
                 if (begin == p) {
                     if (override_state != LXB_URL_STATE__UNDEF) {
-                        lxb_url_parse_return(orig_data, buf, LXB_STATUS_OK);
+                        lxb_url_parse_return(orig_data, buf, LXB_STATUS_ERROR);
                     }
 
                     state = LXB_URL_STATE_PATH_START_STATE;

--- a/test/files/lexbor/url/changes.ton
+++ b/test/files/lexbor/url/changes.ton
@@ -378,7 +378,7 @@
     /* 18 */
     {
         "url": "https://lexbor.com/",
-        "done": "https://example.com/",
+        "done": "https://lexbor.com/",
         "change": {
             "href": null,
             "protocol": null,
@@ -392,9 +392,9 @@
             "hash": null
         },
         "scheme": "https",
-        "host": "example.com",
+        "host": "lexbor.com",
         "path": "/",
-        "failed": false
+        "failed": true
     },
     /* 19 */
     {
@@ -980,5 +980,26 @@
         "host": "333.333.333.333",
         "path": "/path",
         "failed": false
+    },
+    /* 45 */
+    {
+        "url": "https://example.com:432",
+        "done": "https://example.com:432",
+        "change": {
+            "href": null,
+            "protocol": null,
+            "username": null,
+            "password": null,
+            "host": null,
+            "hostname": null,
+            "port": "-1",
+            "pathname": null,
+            "search": null,
+            "hash": null
+        },
+        "scheme": "https",
+        "host": "example.com",
+        "port": "432",
+        "failed": true
     }
 ]


### PR DESCRIPTION
The WHATWG URL Standard specifies that:

> If state override is given, then return failure.

when the buffer is the empty string.

Fixes lexbor/lexbor#306.

--------------

Fixes php/php-src#19944.