### PR TITLE
Core: Reset length in `lexbor_str_destroy()`

### DIFF
--- a/source/lexbor/core/str.c
+++ b/source/lexbor/core/str.c
@@ -80,6 +80,7 @@ lexbor_str_destroy(lexbor_str_t *str, lexbor_mraw_t *mraw, bool destroy_obj)
     }
 
     if (str->data != NULL) {
+        lexbor_str_clean(str);
         str->data = lexbor_mraw_free(mraw, str->data);
     }
 

--- a/test/lexbor/core/str.c
+++ b/test/lexbor/core/str.c
@@ -390,13 +390,19 @@ TEST_END
 
 TEST_BEGIN(destroy_stack)
 {
+    const lxb_char_t *cat = (lxb_char_t *) "Cat";
+    size_t cat_size = strlen((const char *) cat);
+
     lexbor_mraw_t *mraw;
     TEST_CALL_ARGS(test_make_mraw, &mraw);
 
     lexbor_str_t str;
     test_ne(lexbor_str_init(&str, mraw, 128), NULL);
+    lexbor_str_append(&str, mraw, cat, cat_size);
+    test_eq(str.length, 3);
 
     test_eq(lexbor_str_destroy(&str, mraw, false), &str);
+    test_eq(str.length, 0);
     TEST_CALL_ARGS(test_destroy_mraw, &mraw);
 }
 TEST_END


### PR DESCRIPTION
Previously destroying stack-allocated / embedded `lexbor_str_t` structs would have their `.data` field `NULL`ed, but their `.length` field would be left unmodified.

This was observable when resolving a relative URL of `relative` against the URL `https://example.com/path?query` that has a query string. In the resulting URL, the `.query` field would have `.data = NULL` and `.length = 5` which is internally inconsistent.

--------------

Found in php/php-src#19979, because PHP just checks for `if (uri->query.length)` in:

https://github.com/php/php-src/blob/898235127b362d7103fdae8142c05908b7191f60/ext/uri/uri_parser_whatwg.c#L457-L459