### PR TITLE
Added link to the Erlang binding lexbor_erl on hex.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The `liblexbor-html` library already contains all the pointers to the required d
 ## External Bindings and Wrappers
 
 * [Elixir](https://git.pleroma.social/pleroma/elixir-libraries/fast_html) binding for the HTML module (since 2.0 version)
+* [Erlang](https://hex.pm/packages/lexbor_erl) Fast HTML5 Parser with CSS selectors and DOM manipulation (since 2.6.0 version)
 * [Crystal](https://github.com/kostya/lexbor) Fast HTML5 Parser with CSS selectors for Crystal language
 * [Python](https://github.com/rushter/selectolax#available-backends) binding for modest and lexbor engines.
 * [D](https://github.com/trikko/parserino) Fast HTML5 Parser with CSS selectors for D programming language


### PR DESCRIPTION
Hey!

After creating an **Elixir** binding to `Modest` (~7 years ago), I finally found time to follow up and create an **Erlang** binding to the awesome `Lexbor` engine.

Published https://hex.pm/packages/lexbor_erl

This PR adds a link to the README, under external bindings section.

Thank you for this great project! 
I hope this binding helps the adoption in the Erlang ecosystem.

f34nk