### PR TITLE
Fix missing UTF-8 validation in lxb_encoding_decode_valid_utf_8_single()

### DIFF
--- a/source/lexbor/encoding/decode.c
+++ b/source/lexbor/encoding/decode.c
@@ -2907,8 +2907,8 @@ lxb_encoding_decode_valid_utf_8_single(const lxb_char_t **data,
     else if ((*p & 0xe0) == 0xc0) {
         /* 110xxxxx 10xxxxxx */
 
-        if (end - p < 2) {
-            *data = end;
+        if (*p < 0xC2 || end - p < 2 || (p[1] & 0xC0) != 0x80) {
+            (*data) = (end - p < 2) ? end : *data + 1;
             return LXB_ENCODING_DECODE_ERROR;
         }
 
@@ -2920,8 +2920,12 @@ lxb_encoding_decode_valid_utf_8_single(const lxb_char_t **data,
     else if ((*p & 0xf0) == 0xe0) {
         /* 1110xxxx 10xxxxxx 10xxxxxx */
 
-        if (end - p < 3) {
-            *data = end;
+        if (end - p < 3
+            || (p[1] & 0xC0) != 0x80 || (p[2] & 0xC0) != 0x80
+            || (*p == 0xE0 && p[1] < 0xA0)
+            || (*p == 0xED && p[1] > 0x9F))
+        {
+            (*data) = (end - p < 3) ? end : *data + 1;
             return LXB_ENCODING_DECODE_ERROR;
         }
 
@@ -2934,8 +2938,13 @@ lxb_encoding_decode_valid_utf_8_single(const lxb_char_t **data,
     else if ((*p & 0xf8) == 0xf0) {
         /* 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
 
-        if (end - p < 4) {
-            *data = end;
+        if (*p > 0xF4 || end - p < 4
+            || (p[1] & 0xC0) != 0x80 || (p[2] & 0xC0) != 0x80
+            || (p[3] & 0xC0) != 0x80
+            || (*p == 0xF0 && p[1] < 0x90)
+            || (*p == 0xF4 && p[1] > 0x8F))
+        {
+            (*data) = (end - p < 4) ? end : *data + 1;
             return LXB_ENCODING_DECODE_ERROR;
         }
 
@@ -2974,7 +2983,7 @@ lxb_encoding_decode_valid_utf_8_single_reverse(const lxb_char_t **end,
         else if ((*p & 0xe0) == 0xc0) {
             /* 110xxxxx 10xxxxxx */
 
-            if (*end - p < 2) {
+            if (*p < 0xC2 || *end - p < 2 || (p[1] & 0xC0) != 0x80) {
                 *end = p;
                 return LXB_ENCODING_DECODE_ERROR;
             }
@@ -2988,7 +2997,11 @@ lxb_encoding_decode_valid_utf_8_single_reverse(const lxb_char_t **end,
         else if ((*p & 0xf0) == 0xe0) {
             /* 1110xxxx 10xxxxxx 10xxxxxx */
 
-            if (*end - p < 3) {
+            if (*end - p < 3
+                || (p[1] & 0xC0) != 0x80 || (p[2] & 0xC0) != 0x80
+                || (*p == 0xE0 && p[1] < 0xA0)
+                || (*p == 0xED && p[1] > 0x9F))
+            {
                 *end = p;
                 return LXB_ENCODING_DECODE_ERROR;
             }
@@ -3003,7 +3016,12 @@ lxb_encoding_decode_valid_utf_8_single_reverse(const lxb_char_t **end,
         else if ((*p & 0xf8) == 0xf0) {
             /* 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
 
-            if (*end - p < 4) {
+            if (*p > 0xF4 || *end - p < 4
+                || (p[1] & 0xC0) != 0x80 || (p[2] & 0xC0) != 0x80
+                || (p[3] & 0xC0) != 0x80
+                || (*p == 0xF0 && p[1] < 0x90)
+                || (*p == 0xF4 && p[1] > 0x8F))
+            {
                 *end = p;
                 return LXB_ENCODING_DECODE_ERROR;
             }


### PR DESCRIPTION
Fixes #354.

Adds the missing validation to both `lxb_encoding_decode_valid_utf_8_single()` and `lxb_encoding_decode_valid_utf_8_single_reverse()`:

- **2-byte:** reject lead bytes < 0xC2 (overlong), validate continuation byte range
- **3-byte:** validate continuations, reject 0xE0 + < 0xA0 (overlong), reject 0xED + > 0x9F (surrogates)
- **4-byte:** reject lead > 0xF4, validate continuations, reject 0xF0 + < 0x90 (overlong), reject 0xF4 + > 0x8F (> U+10FFFF)

On error, the decoder advances by 1 byte (not the full sequence length) so the next byte gets its own decode attempt, matching browser behavior.

As a separate cleanup, the existing XOR-based bit extraction (`p[n] ^ (0xMM & p[n])`) could be replaced with standard masking (`p[n] & 0x3F`), which is equivalent for valid inputs and more readable. I had this in my original PHP patch but pulled it out here to keep the diff focused on the bug fix. Curious whether the XOR form was chosen intentionally, is there a performance or correctness reason for it, or just a style preference?

I ran the test suite, seems to be no regressions from what I can see.