### PR TITLE
Security: fix OOB reads and integer overflows in parser allocations

### DIFF
--- a/source/lexbor/core/shs.c
+++ b/source/lexbor/core/shs.c
@@ -35,6 +35,12 @@ lexbor_shs_entry_get_static(const lexbor_shs_entry_t *root,
                             const lxb_char_t *key, size_t key_len)
 {
     const lexbor_shs_entry_t *entry;
+
+    /* Guard: key[size - 1] would read out-of-bounds when size == 0. */
+    if (key_len == 0) {
+        return NULL;
+    }
+
     entry = root + lexbor_shs_make_id_m(key, key_len, root->key_len);
 
     while (entry->key != NULL)
@@ -64,6 +70,12 @@ lexbor_shs_entry_get_lower_static(const lexbor_shs_entry_t *root,
                                   const lxb_char_t *key, size_t key_len)
 {
     const lexbor_shs_entry_t *entry;
+
+    /* Guard: key[size - 1] would read out-of-bounds when size == 0. */
+    if (key_len == 0) {
+        return NULL;
+    }
+
     entry = root + lexbor_shs_make_id_lower_m(key, key_len, root->key_len);
 
     while (entry->key != NULL)
@@ -93,6 +105,12 @@ lexbor_shs_entry_get_upper_static(const lexbor_shs_entry_t *root,
                                   const lxb_char_t *key, size_t key_len)
 {
     const lexbor_shs_entry_t *entry;
+
+    /* Guard: key[size - 1] would read out-of-bounds when size == 0. */
+    if (key_len == 0) {
+        return NULL;
+    }
+
     entry = root + lexbor_shs_make_id_upper_m(key, key_len, root->key_len);
 
     while (entry->key != NULL)

--- a/source/lexbor/css/syntax/state.c
+++ b/source/lexbor/css/syntax/state.c
@@ -226,9 +226,19 @@ lxb_inline lxb_status_t
 lxb_css_syntax_string_realloc(lxb_css_syntax_tokenizer_t *tkz, size_t upto)
 {
     size_t len = tkz->pos - tkz->start;
-    size_t size = (tkz->end - tkz->start) + upto;
+    size_t cur = (size_t) (tkz->end - tkz->start);
+    size_t size;
+    lxb_char_t *tmp;
 
-    lxb_char_t *tmp = lexbor_realloc(tkz->start, size);
+    /* Overflow guard: (end - start) + upto. */
+    if (cur > SIZE_MAX - upto) {
+        tkz->status = LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        return tkz->status;
+    }
+
+    size = cur + upto;
+
+    tmp = lexbor_realloc(tkz->start, size);
     if (tmp == NULL) {
         tkz->status = LXB_STATUS_ERROR_MEMORY_ALLOCATION;
         return tkz->status;
@@ -246,6 +256,12 @@ lxb_css_syntax_string_append(lxb_css_syntax_tokenizer_t *tkz,
                              const lxb_char_t *data, size_t length)
 {
     if ((size_t) (tkz->end - tkz->pos) <= length) {
+        /* Overflow guard: length + 1024 below. */
+        if (length > SIZE_MAX - 1024) {
+            tkz->status = LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+            return tkz->status;
+        }
+
         if (lxb_css_syntax_string_realloc(tkz, length + 1024) != LXB_STATUS_OK) {
             return tkz->status;
         }

--- a/source/lexbor/css/syntax/syntax.c
+++ b/source/lexbor/css/syntax/syntax.c
@@ -328,7 +328,19 @@ lxb_css_syntax_stack_expand(lxb_css_parser_t *parser, size_t count)
 
     cur_len = parser->rules - parser->rules_begin;
 
+    /* Overflow guard: cur_len + count + 1024, then * sizeof(...). */
+    if (count > SIZE_MAX - 1024
+        || cur_len > SIZE_MAX - (count + 1024))
+    {
+        return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+    }
+
     length = cur_len + count + 1024;
+
+    if (length > SIZE_MAX / sizeof(lxb_css_syntax_rule_t)) {
+        return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+    }
+
     size = length * sizeof(lxb_css_syntax_rule_t);
 
     p = lexbor_realloc(parser->rules_begin, size);

--- a/source/lexbor/html/serialize.c
+++ b/source/lexbor/html/serialize.c
@@ -1563,6 +1563,11 @@ lxb_html_serialize_pretty_attributes_sorted(lxb_dom_element_t *element,
     }
 
     if (count > sizeof(stack_entries) / sizeof(stack_entries[0])) {
+        /* Overflow guard: attacker-controlled attribute count. */
+        if (count > SIZE_MAX / sizeof(lxb_html_serialize_attr_entry_t)) {
+            return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        }
+
         entries = lexbor_malloc(count * sizeof(lxb_html_serialize_attr_entry_t));
         if (entries == NULL) {
             return LXB_STATUS_ERROR_MEMORY_ALLOCATION;

--- a/source/lexbor/punycode/punycode.c
+++ b/source/lexbor/punycode/punycode.c
@@ -29,8 +29,18 @@ lxb_punycode_encode_realloc(lxb_char_t *p, lxb_char_t **buf,
                             const lxb_char_t **end, const lxb_char_t *buffer)
 {
     size_t cur_size = *end - *buf;
-    size_t nsize = cur_size * 2;
+    size_t nsize;
     lxb_char_t *tmp;
+
+    /* Overflow guard: cur_size * 2. */
+    if (cur_size > SIZE_MAX / 2) {
+        if (*buf != buffer) {
+            lexbor_free(*buf);
+        }
+        return NULL;
+    }
+
+    nsize = cur_size * 2;
 
     if (*buf == buffer) {
         tmp = lexbor_malloc(nsize);
@@ -59,8 +69,20 @@ lxb_punycode_decode_realloc(lxb_codepoint_t *p, lxb_codepoint_t **buf,
                             const lxb_codepoint_t *buffer)
 {
     size_t cur_size = *end - *buf;
-    size_t nsize = cur_size * 2;
+    size_t nsize;
     lxb_codepoint_t *tmp;
+
+    /* Overflow guard: cur_size * 2, then * sizeof(lxb_codepoint_t). */
+    if (cur_size > SIZE_MAX / 2
+        || (cur_size * 2) > SIZE_MAX / sizeof(lxb_codepoint_t))
+    {
+        if (*buf != buffer) {
+            lexbor_free(*buf);
+        }
+        return NULL;
+    }
+
+    nsize = cur_size * 2;
 
     if (*buf == buffer) {
         tmp = lexbor_malloc(nsize * sizeof(lxb_codepoint_t));
@@ -284,6 +306,11 @@ lxb_punycode_encode(const lxb_char_t *data, size_t length,
         cps = input;
     }
     else {
+        /* Overflow guard: cp_length * sizeof(lxb_codepoint_t). */
+        if (cp_length > SIZE_MAX / sizeof(lxb_codepoint_t)) {
+            return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        }
+
         cps = lexbor_malloc(cp_length * sizeof(lxb_codepoint_t));
         if (cps == NULL) {
             return LXB_STATUS_ERROR_MEMORY_ALLOCATION;

--- a/source/lexbor/unicode/idna.c
+++ b/source/lexbor/unicode/idna.c
@@ -113,11 +113,22 @@ lxb_unicode_idna_realloc(lxb_codepoint_t *buf, const lxb_codepoint_t *buffer,
                          lxb_codepoint_t **buf_p, lxb_codepoint_t **buf_end,
                          size_t len)
 {
-    size_t nlen;
+    size_t nlen, cur;
     lxb_codepoint_t *tmp;
 
-    nlen = ((*buf_end - buf) * 4) + len;
- 
+    cur = (size_t) (*buf_end - buf);
+
+    /* Guard against size_t overflow: cur*4 + len, then * sizeof(...). */
+    if (cur > SIZE_MAX / 4 || (cur * 4) > SIZE_MAX - len) {
+        return NULL;
+    }
+
+    nlen = (cur * 4) + len;
+
+    if (nlen > SIZE_MAX / sizeof(lxb_codepoint_t)) {
+        return NULL;
+    }
+
     if (buf == buffer) {
         tmp = lexbor_malloc(nlen * sizeof(lxb_codepoint_t));
         if (tmp == NULL) {
@@ -454,7 +465,17 @@ lxb_unicode_idna_ascii_puny_cb(const lxb_char_t *data, size_t length, void *ctx,
     static const lexbor_str_t prefix = lexbor_str("xn--");
 
     if (asc->p + length + 6 > asc->end) {
-        nlen = ((asc->end - asc->buf) * 4) + length + 6;
+        size_t cur = (size_t) (asc->end - asc->buf);
+
+        /* Overflow guard: cur*4 + length + 6. */
+        if (cur > SIZE_MAX / 4
+            || length > SIZE_MAX - 6
+            || (cur * 4) > SIZE_MAX - (length + 6))
+        {
+            return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        }
+
+        nlen = (cur * 4) + length + 6;
 
         if (asc->buf == asc->buffer) {
             tmp = lexbor_malloc(nlen);
@@ -511,6 +532,12 @@ lxb_unicode_idna_validity_criteria_h(const void *data, size_t length,
     lxb_unicode_idna_type_t type;
 
     p = data;
+
+    /* Guard against size_t overflow when is_cp is true. */
+    if (is_cp && length > SIZE_MAX / sizeof(lxb_codepoint_t)) {
+        return false;
+    }
+
     len = length * ((is_cp) ? sizeof(lxb_codepoint_t) : 1);
     end = (const lxb_char_t *) data + len;
 
@@ -540,7 +567,7 @@ lxb_unicode_idna_validity_criteria_h(const void *data, size_t length,
             }
 
             if (length >= 1) {
-                if (p[0] == 0x002D || p[-1] == 0x002D) {
+                if (p[0] == 0x002D || p[length - 1] == 0x002D) {
                     return false;
                 }
             }
@@ -707,7 +734,17 @@ lxb_unicode_idna_to_unicode_cb(const lxb_codepoint_t *part, size_t len,
     }
 
     if (asc->p + length + 2 > asc->end) {
-        nlen = ((asc->end - asc->buf) * 4) + length + 2;
+        size_t cur = (size_t) (asc->end - asc->buf);
+
+        /* Overflow guard: cur*4 + length + 2. */
+        if (cur > SIZE_MAX / 4
+            || length > SIZE_MAX - 2
+            || (cur * 4) > SIZE_MAX - (length + 2))
+        {
+            return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        }
+
+        nlen = (cur * 4) + length + 2;
 
         if (asc->buf == asc->buffer) {
             tmp = lexbor_malloc(nlen);

--- a/source/lexbor/unicode/unicode.c
+++ b/source/lexbor/unicode/unicode.c
@@ -275,8 +275,25 @@ lxb_unicode_check_buf(lxb_unicode_normalizer_t *uc, lxb_unicode_buffer_t **p,
     static const size_t buf_length = 1024;
 
     if (*p + length >= *end) {
+        size_t cur = (size_t) (uc->end - uc->buf);
+
         len = *p - uc->buf;
-        new_len = (uc->end - uc->buf) + buf_length + length;
+
+        /* Overflow guard: cur + buf_length + length, then * sizeof(...). */
+        if (cur > SIZE_MAX - buf_length
+            || (cur + buf_length) > SIZE_MAX - length)
+        {
+            *p = NULL;
+            return;
+        }
+
+        new_len = cur + buf_length + length;
+
+        if (new_len > SIZE_MAX / sizeof(lxb_unicode_buffer_t)) {
+            *p = NULL;
+            return;
+        }
+
         starter_len = (uc->starter != NULL) ? uc->starter - uc->buf : 0;
 
         buf = lexbor_realloc(uc->buf, new_len * sizeof(lxb_unicode_buffer_t));

--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -492,6 +492,15 @@ lxb_url_scheme_length = sizeof(lxb_url_scheme_res) / sizeof(lxb_url_scheme_data_
                                                                               \
         lst = (last) - (sbuf_begin);                                          \
         offset = (sbuf) - (sbuf_begin);                                       \
+                                                                              \
+        /* Overflow guard: offset << 1 wraps when offset > SIZE_MAX/2. */     \
+        if (offset > (SIZE_MAX >> 1)) {                                       \
+            if ((sbuf_begin) != (sbuffer)) {                                  \
+                lexbor_free(sbuf_begin);                                      \
+            }                                                                 \
+            return NULL;                                                      \
+        }                                                                     \
+                                                                              \
         new_len = offset << 1;                                                \
                                                                               \
         if ((sbuf_begin) == (sbuffer)) {                                      \
@@ -3084,6 +3093,10 @@ oh_my:
     status = lxb_url_log_append(parser, p,
                                 LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
     if (status != LXB_STATUS_OK) {
+        return NULL;
+    }
+
+    if (*length == SIZE_MAX) {
         return NULL;
     }
 


### PR DESCRIPTION
## Summary

Fixes memory-safety issues across lexbor modules that parse untrusted input
(HTML attributes, URLs, IDN domain labels, Unicode text, CSS). Each issue is
either an out-of-bounds read or an integer overflow in heap-allocation
sizing that would wrap to an undersized buffer, enabling subsequent memory
corruption through `memcpy` or pointer writes.

## Out-of-bounds reads

- **`unicode/idna`** — `lxb_unicode_idna_validity_criteria_h` (non-codepoint
  branch) dereferenced `p[-1]` instead of `p[length - 1]`, reading before
  the buffer start. The codepoint branch was already correct.
- **`core/shs`** — `lexbor_shs_entry_get_static`,
  `lexbor_shs_entry_get_lower_static`, and
  `lexbor_shs_entry_get_upper_static` hash a key with macros that
  dereference `key[size - 1]` unconditionally; when `key_len == 0` this
  reads at `key[SIZE_MAX]`. Several public entry points
  (`lxb_css_property_by_name`, `lxb_css_unit_*_by_name`,
  `lxb_css_syntax_token_type_id_by_name`) do not guard length, so the
  zero-length lookup reaches the underflow. Now returns `NULL` early.

## Integer overflows in allocation sizing

- **`unicode/idna`** — `lxb_unicode_idna_realloc`,
  `lxb_unicode_idna_ascii_puny_cb`, `lxb_unicode_idna_to_unicode_cb`, and
  `lxb_unicode_idna_validity_criteria_h` computing `cur*4 + len` and
  `length * sizeof(lxb_codepoint_t)`.
- **`url`** — `LXB_URL_SBUF_REALLOC` (`offset << 1`) and the log-append
  path (`*length + 1`).
- **`html/serialize`** — `count * sizeof(lxb_html_serialize_attr_entry_t)`
  for elements with attacker-controlled attribute counts.
- **`unicode`** — `lxb_unicode_check_buf` growing the codepoint buffer
  (`cur + buf_length + length`, then `* sizeof(lxb_unicode_buffer_t)`).
- **`punycode`** — encode/decode realloc helpers (`cur_size * 2`) and
  `lxb_punycode_encode` (`cp_length * sizeof(lxb_codepoint_t)`).
- **`css/syntax`** — `lxb_css_syntax_stack_expand`
  (`(cur_len + count + 1024) * sizeof(lxb_css_syntax_rule_t)`).
- **`css/syntax`** — `lxb_css_syntax_string_realloc`
  (`(end - start) + upto`) and `lxb_css_syntax_string_append`
  (`length + 1024`).

## Approach

All fixes add explicit `SIZE_MAX` guards that fail closed through the
existing error-return paths (`NULL` for allocator helpers,
`LXB_STATUS_ERROR_MEMORY_ALLOCATION` for status-returning callers,
`*p = NULL` for the unicode normalizer — already handled by every
caller). Order of checks is chosen so the guard runs before any wrapping
arithmetic.

