### PR TITLE
Add lxb_url_is_special() to the public API

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -860,7 +860,7 @@ lxb_url_is_url_codepoint(lxb_codepoint_t cp)
     return lxb_url_codepoint_alphanumeric[(lxb_char_t) cp] != 0xFF;
 }
 
-lxb_inline bool
+bool
 lxb_url_is_special(const lxb_url_t *url)
 {
     return url->scheme.type != LXB_URL_SCHEMEL_TYPE__UNKNOWN;

--- a/source/lexbor/url/url.h
+++ b/source/lexbor/url/url.h
@@ -763,6 +763,15 @@ LXB_API lxb_status_t
 lxb_url_search_params_serialize(lxb_url_search_params_t *search_params,
                                 lexbor_callback_f cb, void *ctx);
 
+/**
+ * Returns whether the URL is special.
+ *
+ * @param[in] lxb_url_t *. Cannot be NULL.
+ * @return true if URL is special, false otherwise.
+ */
+LXB_API bool
+lxb_url_is_special(const lxb_url_t *url);
+
 /*
  * Inline functions.
  */


### PR DESCRIPTION
As https://wiki.php.net/rfc/uri_followup#uri_type_detection relies on this information.