### PR TITLE
Build: fixed -Wshadow warnings reported by clang.

### DIFF
--- a/source/lexbor/css/syntax/state.c
+++ b/source/lexbor/css/syntax/state.c
@@ -492,7 +492,6 @@ lxb_css_syntax_state_string(lxb_css_syntax_tokenizer_t *tkz, lxb_css_syntax_toke
 {
     lxb_char_t mark;
     const lxb_char_t *begin;
-    lxb_codepoint_t cp;
 
     mark = *data++;
     begin = data;
@@ -562,6 +561,7 @@ lxb_css_syntax_state_string(lxb_css_syntax_tokenizer_t *tkz, lxb_css_syntax_toke
                             begin = data;
                         }
                         else {
+                            lxb_codepoint_t cp;
                             cp = lxb_css_syntax_state_decode_utf_8_up_80(&data, end);
 
                             if (cp == LXB_CSS_SYNTAX_ERROR_CODEPOINT) {

--- a/source/lexbor/dom/interfaces/character_data.c
+++ b/source/lexbor/dom/interfaces/character_data.c
@@ -98,11 +98,10 @@ lxb_dom_character_data_replace(lxb_dom_character_data_t *ch_data,
         }
     }
     else if (lexbor_str_size(&ch_data->data) < len) {
-        const lxb_char_t *data;
-
-        data = lexbor_str_realloc(&ch_data->data,
-                                  ch_data->node.owner_document->text, (len + 1));
-        if (data == NULL) {
+        if (lexbor_str_realloc(&ch_data->data,
+                               ch_data->node.owner_document->text,
+                               (len + 1)) == NULL)
+        {
             return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
         }
     }

--- a/source/lexbor/html/serialize_ext.c
+++ b/source/lexbor/html/serialize_ext.c
@@ -21,46 +21,46 @@
 #define lxb_html_serialize_ext_boundary_send(cb, node, data, len, ctx,         \
                                              level, is_close)                  \
     do {                                                                       \
-        lxb_status_t status = (cb)((node), (data), (len), (ctx),               \
-                                   (level), (is_close));                       \
-        if (status != LXB_STATUS_OK) {                                         \
-            return status;                                                     \
+        lxb_status_t _status = (cb)((node), (data), (len), (ctx),              \
+                                    (level), (is_close));                      \
+        if (_status != LXB_STATUS_OK) {                                        \
+            return _status;                                                    \
         }                                                                      \
     }                                                                          \
     while (0)
 
 #define lxb_html_serialize_ext_name_send(cb, node, data, len, ctx, is_close)   \
     do {                                                                       \
-        lxb_status_t status = (cb)((node), (data), (len), (ctx), (is_close));  \
-        if (status != LXB_STATUS_OK) {                                         \
-            return status;                                                     \
+        lxb_status_t _status = (cb)((node), (data), (len), (ctx), (is_close)); \
+        if (_status != LXB_STATUS_OK) {                                        \
+            return _status;                                                    \
         }                                                                      \
     }                                                                          \
     while (0)
 
 #define lxb_html_serialize_ext_attr_send(cb, node, attr, data, len, ctx)       \
     do {                                                                       \
-        lxb_status_t status = (cb)((node), (attr), (data), (len), (ctx));      \
-        if (status != LXB_STATUS_OK) {                                         \
-            return status;                                                     \
+        lxb_status_t _status = (cb)((node), (attr), (data), (len), (ctx));     \
+        if (_status != LXB_STATUS_OK) {                                        \
+            return _status;                                                    \
         }                                                                      \
     }                                                                          \
     while (0)
 
 #define lxb_html_serialize_ext_text_send(cb, node, data, len, ctx)             \
     do {                                                                       \
-        lxb_status_t status = (cb)((node), (data), (len), (ctx));              \
-        if (status != LXB_STATUS_OK) {                                         \
-            return status;                                                     \
+        lxb_status_t _status = (cb)((node), (data), (len), (ctx));             \
+        if (_status != LXB_STATUS_OK) {                                        \
+            return _status;                                                    \
         }                                                                      \
     }                                                                          \
     while (0)
 
 #define lxb_html_serialize_ext_send(cb, data, len, ctx)                        \
     do {                                                                       \
-        lxb_status_t status = (cb)((data), (len), (ctx));                      \
-        if (status != LXB_STATUS_OK) {                                         \
-            return status;                                                     \
+        lxb_status_t _status = (cb)((data), (len), (ctx));                     \
+        if (_status != LXB_STATUS_OK) {                                        \
+            return _status;                                                    \
         }                                                                      \
     }                                                                          \
     while (0)
@@ -68,11 +68,11 @@
 #define lxb_html_serialize_ext_indent_send(cb, ctx, indent, level, opt)        \
     do {                                                                       \
         if ((opt) & LXB_HTML_SERIALIZE_EXT_OPT_PRETTY) {                       \
-            lxb_status_t status = lxb_html_serialize_ext_indent((cb), (ctx),   \
-                                                                (indent),      \
-                                                                (level));      \
-            if (status != LXB_STATUS_OK) {                                     \
-                return status;                                                 \
+            lxb_status_t _status = lxb_html_serialize_ext_indent((cb), (ctx),  \
+                                                                 (indent),     \
+                                                                 (level));     \
+            if (_status != LXB_STATUS_OK) {                                    \
+                return _status;                                                \
             }                                                                  \
         }                                                                      \
     }                                                                          \
@@ -80,11 +80,11 @@
 
 #define lxb_html_serialize_ext_newline_send(cb, ctx, level)                    \
     do {                                                                       \
-        lxb_status_t status = (cb)((lxb_html_serialize_ext_nl_str.data),       \
-                                   (lxb_html_serialize_ext_nl_str.length),     \
-                                   (ctx), (level));                            \
-        if (status != LXB_STATUS_OK) {                                         \
-            return status;                                                     \
+        lxb_status_t _status = (cb)((lxb_html_serialize_ext_nl_str.data),      \
+                                    (lxb_html_serialize_ext_nl_str.length),    \
+                                    (ctx), (level));                           \
+        if (_status != LXB_STATUS_OK) {                                        \
+            return _status;                                                    \
         }                                                                      \
     }                                                                          \
     while (0)

--- a/source/lexbor/html/tokenizer/state.h
+++ b/source/lexbor/html/tokenizer/state.h
@@ -59,14 +59,14 @@ extern "C" {
 
 #define lxb_html_tokenizer_state_set_name_m(tkz)                               \
     do {                                                                       \
-        lxb_dom_attr_data_t *data;                                             \
-        data = lxb_dom_attr_local_name_append(tkz->attrs, tkz->start,          \
-                                              tkz->pos - tkz->start);          \
-        if (data == NULL) {                                                    \
+        lxb_dom_attr_data_t *_attr_data;                                       \
+        _attr_data = lxb_dom_attr_local_name_append(tkz->attrs, tkz->start,    \
+                                                    tkz->pos - tkz->start);    \
+        if (_attr_data == NULL) {                                              \
             tkz->status = LXB_STATUS_ERROR_MEMORY_ALLOCATION;                  \
             return end;                                                        \
         }                                                                      \
-        tkz->token->attr_last->name = data;                                    \
+        tkz->token->attr_last->name = _attr_data;                              \
     }                                                                          \
     while (0)
 

--- a/source/lexbor/html/tree.c
+++ b/source/lexbor/html/tree.c
@@ -1493,7 +1493,6 @@ lxb_html_tree_adoption_agency_algorithm(lxb_html_tree_t *tree,
         size_t bookmark = formatting_index;
 
         /* State 14 */
-        lxb_dom_node_t *node;
         lxb_dom_node_t *last = furthest_block;
         size_t node_idx = furthest_block_idx;
 

--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -488,30 +488,30 @@ lxb_url_scheme_length = sizeof(lxb_url_scheme_res) / sizeof(lxb_url_scheme_data_
 #define LXB_URL_SBUF_REALLOC(sbuf, sbuf_begin, sbuf_end, sbuffer, last)       \
     do {                                                                      \
         size_t new_len, offset, lst;                                          \
-        lxb_char_t *tmp;                                                      \
+        lxb_char_t *_tmp;                                                     \
                                                                               \
         lst = (last) - (sbuf_begin);                                          \
         offset = (sbuf) - (sbuf_begin);                                       \
         new_len = offset << 1;                                                \
                                                                               \
         if ((sbuf_begin) == (sbuffer)) {                                      \
-            tmp = lexbor_malloc(new_len);                                     \
-            if (tmp == NULL) {                                                \
+            _tmp = lexbor_malloc(new_len);                                    \
+            if (_tmp == NULL) {                                               \
                 return NULL;                                                  \
             }                                                                 \
         }                                                                     \
         else {                                                                \
-            tmp = lexbor_realloc((sbuf_begin), new_len);                      \
-            if (tmp == NULL) {                                                \
+            _tmp = lexbor_realloc((sbuf_begin), new_len);                     \
+            if (_tmp == NULL) {                                               \
                 lexbor_free(sbuf_begin);                                      \
                 return NULL;                                                  \
             }                                                                 \
         }                                                                     \
                                                                               \
-        (sbuf) = tmp + offset;                                                \
+        (sbuf) = _tmp + offset;                                               \
         (last) = sbuf + lst;                                                  \
-        (sbuf_begin) = tmp;                                                   \
-        (sbuf_end) = tmp + new_len;                                           \
+        (sbuf_begin) = _tmp;                                                  \
+        (sbuf_end) = _tmp + new_len;                                          \
     }                                                                         \
     while (false)
 


### PR DESCRIPTION
Building with clang -Wall -Wextra -Wpedantic -Wshadow produced 104 declaration-shadows-a-local-variable warnings across the library.

The fixes are mechanical and behavior-preserving:

  * source/lexbor/html/serialize_ext.c: rename the internal "status" variable inside the lxb_html_serialize_ext_*_send() macros to "_status" so it no longer shadows the surrounding function-local "status".

  * source/lexbor/url/url.c: rename the internal "tmp" variable inside the LXB_URL_SBUF_REALLOC() macro to "_tmp" so it no longer shadows the outer "tmp" in lxb_url_path_slow_path().

  * source/lexbor/html/tokenizer/state.h: rename the internal "data" variable inside lxb_html_tokenizer_state_set_name_m() to "_attr_data" so it no longer shadows the surrounding function-local "data".

  * source/lexbor/css/syntax/state.c: remove the redundant outer "cp" declaration in lxb_css_syntax_state_string() and instead declare it where it is actually used, so the macro-introduced "cp" in LXB_CSS_SYNTAX_UTF_8_UP_80_BLOCK() no longer shadows it.

  * source/lexbor/html/tree.c: remove the redundant inner "lxb_dom_node_t *node" declaration in the adoption-agency inner loop (the outer "node" declared at function scope is reused later anyway).

  * source/lexbor/dom/interfaces/character_data.c: drop the unused inner "data" local in lxb_dom_character_data_replace(); the realloc result was assigned and never read, the actual target buffer is ch_data->data.data which lexbor_str_realloc() updates in place.

After these changes a clang build with the flags above produces zero warnings, and all 134 ctest cases continue to pass.