### PR TITLE
Fix condition check for tokenizer size limits

### DIFF
--- a/source/lexbor/html/tokenizer.h
+++ b/source/lexbor/html/tokenizer.h
@@ -310,7 +310,7 @@ lxb_html_tokenizer_temp_append_data(lxb_html_tokenizer_t *tkz,
 {
     size_t size = data - tkz->begin;
 
-    if ((tkz->pos + size) > tkz->end) {
+    if (size > (size_t)(tkz->end - tkz->pos)) {
         if(lxb_html_tokenizer_temp_realloc(tkz, size)) {
             return tkz->status;
         }
@@ -325,7 +325,7 @@ lxb_inline lxb_status_t
 lxb_html_tokenizer_temp_append(lxb_html_tokenizer_t *tkz,
                                const lxb_char_t *data, size_t size)
 {
-    if ((tkz->pos + size) > tkz->end) {
+    if (size > (size_t)(tkz->end - tkz->pos)) {
         if(lxb_html_tokenizer_temp_realloc(tkz, size)) {
             return tkz->status;
         }


### PR DESCRIPTION
There is a pointer wraparound in the tokenizer.h header file. This is a simple proof of concept of how it works.

```cpp
#include <lexbor/html/tokenizer.h>
#include <stdio.h>
#include <stdint.h>

int main(void) {
    lxb_html_tokenizer_t *tkz = lxb_html_tokenizer_create();
    lxb_html_tokenizer_init(tkz);
    lxb_html_tokenizer_begin(tkz);

    size_t huge_size = (size_t)-50; 
    
    printf("tkz->pos pointer %p\n", (void*)tkz->pos);
    printf("tkz->end pointer %p\n", (void*)tkz->end);
    printf("%zu\n", huge_size);
    printf("(tkz->pos + huge_size) %p\n", (void*)(tkz->pos + huge_size));
    
    // The bad check from tokenizer.h
    if ((tkz->pos + huge_size) > tkz->end) {
        printf("Safe :D \n");
    } else {
        printf("not Safe :( \n");
    }
    
    return 0;
}
```

and if you run it, this would be the output:

```
tkz->pos pointer 0x529000000200
tkz->end pointer 0x529000004200
18446744073709551566
(tkz->pos + huge_size) 0x5290000001ce
not Safe :(
```

now if this is not enough as a proof, I wrote a simple usecase of the function and this is the results.
```
tkz->pos = 0x529000000200
tkz->end = 0x529000004200
Calling lxb_html_tokenizer_temp_append() with 18446744073709551516
==5497==ERROR: AddressSanitizer: negative-size-param: (size=-100)
    #0 0x7971a46fb5bd in memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
    #1 0x55b503829679 in lxb_html_tokenizer_temp_append /usr/local/include/lexbor/html/tokenizer.h:334
    #2 0x55b5038297da in main /home/sland/lexbor/test1.c:31
    #3 0x7971a3e2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #4 0x7971a3e2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #5 0x55b503829264 in _start (/home/sland/lexbor/test1+0x1264) (BuildId: 33d65222c1d389d26e2f19e0a48f6a0ed4e4ba91)

0x55b50382a0a0 is located 0 bytes inside of global variable '*.LC2' defined in 'test1.c' (0x55b50382a0a0) of size 18
  '*.LC2' is ascii string 'Somedataasexample'
SUMMARY: AddressSanitizer: negative-size-param ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115 in memcpy
==5497==ABORTING
```