### PR TITLE
Selectors: match ID and class selectors case-sensitively except in quirks mode

### DIFF
--- a/source/lexbor/selectors/selectors.c
+++ b/source/lexbor/selectors/selectors.c
@@ -1310,7 +1310,9 @@ lxb_selectors_match(lxb_selectors_t *selectors, lxb_selectors_entry_t *entry,
             }
 
             return lxb_selectors_match_class(element->attr_class->value,
-                                             &entry->selector->name, true);
+                                             &entry->selector->name,
+                                             node->owner_document->compat_mode
+                                             == LXB_DOM_DOCUMENT_CMODE_QUIRKS);
 
         case LXB_CSS_SELECTOR_TYPE_ATTRIBUTE:
             return lxb_selectors_match_attribute(entry->selector, node, entry);
@@ -1368,8 +1370,15 @@ lxb_selectors_match_id(const lxb_css_selector_t *selector, lxb_dom_node_t *node)
     trg = element->attr_id->value;
     src = &selector->name;
 
-    return trg->length == src->length
-           && lexbor_str_data_ncasecmp(trg->data, src->data, src->length);
+    if (trg->length != src->length) {
+        return false;
+    }
+
+    if (node->owner_document->compat_mode == LXB_DOM_DOCUMENT_CMODE_QUIRKS) {
+        return lexbor_str_data_ncasecmp(trg->data, src->data, src->length);
+    }
+
+    return lexbor_str_data_ncmp(trg->data, src->data, src->length);
 }
 
 static bool

--- a/test/lexbor/selectors/selectors.c
+++ b/test/lexbor/selectors/selectors.c
@@ -17,6 +17,13 @@ typedef struct {
 }
 lxb_test_entry_t;
 
+typedef struct {
+    lxb_dom_document_cmode_t mode;
+    const char *sel;
+    size_t expected;
+}
+test_case_count_t;
+
 static const lxb_char_t html[] =
     "<div div='First' class='Strong Massive'>"
     "    <p p=1><a a=1>a1</a></p>"
@@ -895,6 +902,68 @@ TEST_BEGIN(match_first)
 }
 TEST_END
 
+TEST_BEGIN(match_id_class_case)
+{
+    size_t count;
+    lxb_status_t status;
+    lxb_dom_node_t *node;
+    lxb_selectors_t *selectors;
+    lxb_css_parser_t *parser;
+    lxb_css_selector_list_t *list;
+    lxb_html_document_t *document;
+    lxb_dom_document_t *dom_document;
+
+    static const test_case_count_t cases[] = {
+        {LXB_DOM_DOCUMENT_CMODE_NO_QUIRKS, ".test", 0},
+        {LXB_DOM_DOCUMENT_CMODE_NO_QUIRKS, "#foo", 0},
+        {LXB_DOM_DOCUMENT_CMODE_NO_QUIRKS, ".Test", 1},
+        {LXB_DOM_DOCUMENT_CMODE_NO_QUIRKS, "#Foo", 1},
+        {LXB_DOM_DOCUMENT_CMODE_QUIRKS, ".test", 1},
+        {LXB_DOM_DOCUMENT_CMODE_QUIRKS, "#foo", 1}
+    };
+
+    static const lxb_char_t html[] =
+        "<!DOCTYPE html><div class='Test'><span id='Foo'></span></div>";
+
+    size_t cases_length = sizeof(cases) / sizeof(test_case_count_t);
+
+    document = lxb_html_document_create();
+    status = lxb_html_document_parse(document, html, sizeof(html) - 1);
+    test_eq(status, LXB_STATUS_OK);
+
+    parser = lxb_css_parser_create();
+    status = lxb_css_parser_init(parser, NULL);
+    test_eq(status, LXB_STATUS_OK);
+
+    selectors = lxb_selectors_create();
+    status = lxb_selectors_init(selectors);
+    test_eq(status, LXB_STATUS_OK);
+
+    node = lxb_dom_interface_node(lxb_html_document_body_element(document));
+    dom_document = lxb_dom_interface_document(document);
+
+    for (size_t i = 0; i < cases_length; i++) {
+        dom_document->compat_mode = cases[i].mode;
+
+        list = lxb_css_selectors_parse(parser, (const lxb_char_t *) cases[i].sel,
+                                       strlen(cases[i].sel));
+        test_ne(list, NULL);
+
+        count = 0;
+        status = lxb_selectors_find(selectors, node, list,
+                                    find_callback_count, &count);
+        test_eq(status, LXB_STATUS_OK);
+        test_eq(count, cases[i].expected);
+
+        lxb_css_parser_erase(parser);
+    }
+
+    (void) lxb_html_document_destroy(document);
+    (void) lxb_css_parser_destroy(parser, true);
+    (void) lxb_selectors_destroy(selectors, true);
+}
+TEST_END
+
 int
 main(int argc, const char * argv[])
 {
@@ -905,6 +974,7 @@ main(int argc, const char * argv[])
     TEST_ADD(match_root);
     TEST_ADD(match_root_document);
     TEST_ADD(match_first);
+    TEST_ADD(match_id_class_case);
 
     TEST_RUN("lexbor/selectors/selectors");
     TEST_RELEASE();


### PR DESCRIPTION
Fixes #368.

In `lxb_selectors_match()`, the third argument passed to `lxb_selectors_match_class()` is no longer hard-coded to `true`.
Instead, it is determined based on `node->owner_document->compat_mode`.

In addition, `lxb_selectors_match_id()` now uses either `lexbor_str_data_ncasecmp()` or `lexbor_str_data_ncmp()` as appropriate.