### PR TITLE
CSS: fixed namespace prefix-less type selector to not default to universal namespace.

### DIFF
--- a/source/lexbor/css/selectors/state.c
+++ b/source/lexbor/css/selectors/state.c
@@ -1138,6 +1138,9 @@ lxb_css_selectors_state_element_ns(lxb_css_parser_t *parser,
         return lxb_css_selectors_state_ns(parser, selector);
     }
 
+    selector->name.data[0] = '\0';
+    selector->name.length = 0;
+
     lxb_css_syntax_parser_consume(parser);
 
     return lxb_css_selectors_state_ns_ident(parser, selector);

--- a/test/lexbor/css/selectors/selectors.c
+++ b/test/lexbor/css/selectors/selectors.c
@@ -59,12 +59,12 @@ static const lxb_test_entry_t selectors_list[] =
      lxb_css_selectors_parse},
 
     {"|div",
-     "*|div",
+     "|div",
      "",
      lxb_css_selectors_parse},
 
     {"* |div",
-     "* *|div",
+     "* |div",
      "",
      lxb_css_selectors_parse},
 
@@ -74,7 +74,7 @@ static const lxb_test_entry_t selectors_list[] =
      lxb_css_selectors_parse},
 
     {"html |div",
-     "html *|div",
+     "html |div",
      "",
      lxb_css_selectors_parse},
 


### PR DESCRIPTION
Fixes #370.

`lxb_css_selectors_state_element_ns()` is the shared entry point for selectors that start with `*` or `|`.

This change makes the parser set `selector->name.data` to an empty string when the token does not start with `*`, before continuing with `lxb_css_selectors_state_ns_ident(parser, selector)`.

The tests are also updated accordingly.