### PR TITLE
HTML: treat U+000C FORM FEED as whitespace in tree construction

### DIFF
--- a/source/lexbor/html/token.c
+++ b/source/lexbor/html/token.c
@@ -192,6 +192,7 @@ lxb_html_token_data_skip_ws_begin(lxb_html_token_t *token)
              */
             case 0x09:
             case 0x0A:
+            case 0x0C:
             case 0x0D:
             case 0x20:
                 break;

--- a/test/files/lexbor/html/html5_test/issue375.ton
+++ b/test/files/lexbor/html/html5_test/issue375.ton
@@ -1,0 +1,56 @@
+[
+    /* Test count: 4 */
+    /* Test number: 1 */
+    {
+        "data": $DATA{ ,12}
+            <html><head></head>\f<body>a
+        $DATA,
+        "result": $DATA{ ,12}
+            <html>
+              <head>
+              "\f"
+              <body>
+                "a"
+        $DATA
+    },
+    /* Test number: 2 */
+    {
+        "data": $DATA{ ,12}
+            \fa
+        $DATA,
+        "result": $DATA{ ,12}
+            <html>
+              <head>
+              <body>
+                "a"
+        $DATA
+    },
+    /* Test number: 3 */
+    {
+        "data": $DATA{ ,12}
+            <head>\fa</head><body>b
+        $DATA,
+        "result": $DATA{ ,12}
+            <html>
+              <head>
+                "\f"
+              <body>
+                "ab"
+        $DATA
+    },
+    /* Test number: 4 */
+    {
+        "data": $DATA{ ,12}
+            <table><colgroup>\f<col>
+        $DATA,
+        "result": $DATA{ ,12}
+            <html>
+              <head>
+              <body>
+                <table>
+                  <colgroup>
+                    "\f"
+                    <col>
+        $DATA
+    }
+]


### PR DESCRIPTION
Fixes #375.

`lxb_html_token_data_skip_ws_begin()` did not treat U+000C FORM FEED as whitespace, so an FF reaching the "initial", "before html", "before head", "in head", "after head", or "in column group" insertion modes was handled as ordinary text: it prematurely opened `<body>` (or popped `<colgroup>`) and the FF landed in the wrong text node. The spec handles all ASCII whitespace (tab, LF, FF, CR, space) specially in these modes.

### History

The pre-2020 implementation handled all five code points. The refactoring in 51930b4 dropped `case 0x0C:` from the switch while deleting the U+000D CR line from the comment — apparently a transcription slip: the comment still lists FF, while CR remained handled but undocumented.

### Note on CR

`case 0x0D:` is unreachable: every text-producing tokenizer state normalizes CR/CRLF to LF before token text is set, matching the spec's input-stream preprocessing. This PR deliberately restores only the missing FF line to keep the diff minimal. If you prefer, the CR case could instead be removed (completing what 51930b4 apparently intended) — happy to do that here or in a follow-up.

### Tests

`test/files/lexbor/html/html5_test/issue375.ton` adds four tree-construction cases: initial (FF ignored), in head, after head (FF text node between `</head>` and `<body>`), and in column group (previously the FF was ejected from `<colgroup>` and `<col>` created a second one). Each case fails without the fix; the harness exercises whole-document and chunked parsing. Full suite passes: tree builder 1800/1800, ctest 135/135.
