### PR TITLE
Fix parsing for URLs containing userinfo with empty host

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -1814,7 +1814,7 @@ again:
         if (at_sign) {
             if (begin == p || begin == p - 1) {
                 status = lxb_url_log_append(parser, p,
-                                            LXB_URL_ERROR_TYPE_INVALID_CREDENTIALS);
+                                            LXB_URL_ERROR_TYPE_HOST_MISSING);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
                 }

--- a/test/files/lexbor/url/username_password.ton
+++ b/test/files/lexbor/url/username_password.ton
@@ -1,5 +1,5 @@
 [
-    /* Test count: 11 */
+    /* Test count: 12 */
     /* 1 */
     {
         "url": "https://user:password@lexbor.com",
@@ -122,6 +122,12 @@
         "host": "lexbor.com",
         "path": "/",
         "failed": false,
+        "encoding": "utf-8"
+    }
+    /* 12 */
+    {
+        "url": "https://user:pass@",
+        "failed": true,
         "encoding": "utf-8"
     }
 ]


### PR DESCRIPTION
The returned error code (`LXB_URL_ERROR_TYPE_INVALID_CREDENTIALS`) apparently contradicts the specification:

> If atSignSeen is true and buffer is the empty string, host-missing validation error, return failure.

Originally reported at https://github.com/php/php-src/issues/22629