### PR TITLE
url: Fix use-after-poision ASAN failure

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -3443,9 +3443,6 @@ lxb_url_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
 
     if (lxb_url_is_ipv4(parser, domain->data, end)) {
         status = lxb_url_ipv4_parse(parser, domain->data, end, &ipv4);
-
-        (void) lexbor_str_destroy(domain, mraw, false);
-
         if (status != LXB_STATUS_OK) {
             return status;
         }

--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -506,6 +506,39 @@ lxb_url_scheme_length = sizeof(lxb_url_scheme_res) / sizeof(lxb_url_scheme_data_
     (((data) >= 'a' && (data) <= 'z') || ((data) >= 'A' && (data) <= 'Z'))
 
 
+typedef struct lxb_url_log_buffer lxb_url_log_buffer_t;
+
+struct lxb_url_log_buffer {
+    lxb_url_log_buffer_t *next;
+    uintptr_t           address;
+    size_t              length;
+    lxb_char_t          data[];
+};
+
+typedef struct {
+    lexbor_plog_t        log;
+    lxb_url_log_buffer_t *buffers;
+}
+lxb_url_log_t;
+
+static void
+lxb_url_log_clean(lexbor_plog_t *plog)
+{
+    lxb_url_log_buffer_t *buffer, *next;
+    lxb_url_log_t *log = (lxb_url_log_t *) plog;
+
+    buffer = log->buffers;
+
+    while (buffer != NULL) {
+        next = buffer->next;
+        lexbor_free(buffer);
+        buffer = next;
+    }
+
+    log->buffers = NULL;
+    lexbor_plog_clean(plog);
+}
+
 static lxb_status_t
 lxb_url_leading_trailing(lxb_url_parser_t *parser,
                          const lxb_char_t **data, size_t *length);
@@ -669,7 +702,7 @@ lxb_url_parser_clean(lxb_url_parser_t *parser)
     parser->url = NULL;
 
     if (parser->log != NULL) {
-        lexbor_plog_clean(parser->log);
+        lxb_url_log_clean(parser->log);
     }
 
     if (parser->buffer != NULL) {
@@ -684,7 +717,10 @@ lxb_url_parser_destroy(lxb_url_parser_t *parser, bool destroy_self)
         return NULL;
     }
 
-    parser->log = lexbor_plog_destroy(parser->log, true);
+    if (parser->log != NULL) {
+        lxb_url_log_clean(parser->log);
+        parser->log = lexbor_plog_destroy(parser->log, true);
+    }
     parser->idna = lxb_unicode_idna_destroy(parser->idna, true);
 
     if (parser->buffer != NULL) {
@@ -704,23 +740,67 @@ lxb_url_parser_memory_destroy(lxb_url_parser_t *parser)
     parser->mraw = lexbor_mraw_destroy(parser->mraw, true);
 }
 
+/*
+ * Contexts belong to the log, independently of the input and URL memory.
+ * Keep them separately from the entries, which callers may pop from the log.
+ */
 static lxb_status_t
 lxb_url_log_append(lxb_url_parser_t *parser, const lxb_char_t *pos,
-                   lxb_url_error_type_t type)
+                   const lxb_char_t *end, lxb_url_error_type_t type)
 {
-    void *entry;
+    size_t length, offset;
+    uintptr_t address;
     lxb_status_t status;
+    lxb_url_log_t *log;
+    lxb_url_log_buffer_t *buffer;
 
     if (parser->log == NULL) {
-        parser->log = lexbor_plog_create();
-        status = lexbor_plog_init(parser->log, 5, sizeof(lexbor_plog_entry_t));
+        log = lexbor_calloc(1, sizeof(lxb_url_log_t));
+        if (log == NULL) {
+            return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        }
+
+        status = lexbor_plog_init(&log->log, 5, sizeof(lexbor_plog_entry_t));
         if (status != LXB_STATUS_OK) {
+            lexbor_plog_destroy(&log->log, true);
             return status;
         }
+
+        parser->log = &log->log;
     }
 
-    entry = lexbor_plog_push(parser->log, pos, NULL, type);
-    if (entry == NULL) {
+    log = (lxb_url_log_t *) parser->log;
+    buffer = log->buffers;
+    length = end - pos;
+    address = (uintptr_t) pos;
+
+    /* Reuse a copied suffix for subsequent errors in the same input range. */
+    if (buffer != NULL && address >= buffer->address
+        && address - buffer->address <= buffer->length
+        && length == buffer->length - (address - buffer->address))
+    {
+        offset = address - buffer->address;
+    }
+    else {
+        if (length > SIZE_MAX - sizeof(lxb_url_log_buffer_t) - 1) {
+            return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        }
+
+        buffer = lexbor_malloc(sizeof(lxb_url_log_buffer_t) + length + 1);
+        if (buffer == NULL) {
+            return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
+        }
+
+        buffer->next = log->buffers;
+        buffer->address = address;
+        buffer->length = length;
+        memcpy(buffer->data, pos, length);
+        buffer->data[length] = '\0';
+        log->buffers = buffer;
+        offset = 0;
+    }
+
+    if (lexbor_plog_push(parser->log, buffer->data + offset, NULL, type) == NULL) {
         return LXB_STATUS_ERROR_MEMORY_ALLOCATION;
     }
 
@@ -1447,7 +1527,7 @@ again:
 
         if (schm->type == LXB_URL_SCHEMEL_TYPE_FILE) {
             if (end - p < 2 || p[0] != '/' || p[1] != '/') {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                   LXB_URL_ERROR_TYPE_SPECIAL_SCHEME_MISSING_FOLLOWING_SOLIDUS);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -1532,7 +1612,7 @@ again:
             goto again;
         }
 
-        status = lxb_url_log_append(parser, p,
+        status = lxb_url_log_append(parser, p, end,
                   LXB_URL_ERROR_TYPE_SPECIAL_SCHEME_MISSING_FOLLOWING_SOLIDUS);
         if (status != LXB_STATUS_OK) {
             lxb_url_parse_return(orig_data, buf, status);
@@ -1568,7 +1648,7 @@ again:
             if (lxb_url_is_special(url) && *p == '\\') {
                 p += 1;
 
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                    LXB_URL_ERROR_TYPE_INVALID_REVERSE_SOLIDUS);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -1644,7 +1724,7 @@ again:
 
         if (lxb_url_is_special(url) && (c == '/' || c == '\\')) {
             if (c == '\\') {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                    LXB_URL_ERROR_TYPE_INVALID_REVERSE_SOLIDUS);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -1694,7 +1774,7 @@ again:
             p += 2;
         }
         else {
-            status = lxb_url_log_append(parser, p,
+            status = lxb_url_log_append(parser, p, end,
                   LXB_URL_ERROR_TYPE_SPECIAL_SCHEME_MISSING_FOLLOWING_SOLIDUS);
             if (status != LXB_STATUS_OK) {
                 lxb_url_parse_return(orig_data, buf, status);
@@ -1709,7 +1789,7 @@ again:
             goto again;
         }
 
-        status = lxb_url_log_append(parser, p,
+        status = lxb_url_log_append(parser, p, end,
                   LXB_URL_ERROR_TYPE_SPECIAL_SCHEME_MISSING_FOLLOWING_SOLIDUS);
         if (status != LXB_STATUS_OK) {
             lxb_url_parse_return(orig_data, buf, status);
@@ -1728,7 +1808,7 @@ again:
 
             switch (c) {
                 case '@':
-                    status = lxb_url_log_append(parser, p,
+                    status = lxb_url_log_append(parser, p, end,
                                                 LXB_URL_ERROR_TYPE_INVALID_CREDENTIALS);
                     if (status != LXB_STATUS_OK) {
                         lxb_url_parse_return(orig_data, buf, status);
@@ -1797,7 +1877,7 @@ again:
 
         if (at_sign) {
             if (begin == p || begin == p - 1) {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                             LXB_URL_ERROR_TYPE_HOST_MISSING);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -1955,7 +2035,7 @@ again:
                     port = lexbor_str_res_map_num[*begin++] + port * 10;
 
                     if (port > 65535) {
-                        status = lxb_url_log_append(parser, p,
+                        status = lxb_url_log_append(parser, p, end,
                                           LXB_URL_ERROR_TYPE_PORT_OUT_OF_RANGE);
                         if (status != LXB_STATUS_OK) {
                             lxb_url_parse_return(orig_data, buf, status);
@@ -1985,7 +2065,7 @@ again:
                 goto again;
             }
 
-            status = lxb_url_log_append(parser, p,
+            status = lxb_url_log_append(parser, p, end,
                                         LXB_URL_ERROR_TYPE_PORT_INVALID);
             if (status != LXB_STATUS_OK) {
                 lxb_url_parse_return(orig_data, buf, status);
@@ -2010,7 +2090,7 @@ again:
 
         if (c == '/' || c == '\\') {
             if (c == '\\') {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                    LXB_URL_ERROR_TYPE_INVALID_REVERSE_SOLIDUS);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2069,7 +2149,7 @@ again:
                 lxb_url_path_shorten(url);
             }
             else {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                           LXB_URL_ERROR_TYPE_FILE_INVALID_WINDOWS_DRIVE_LETTER);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2088,7 +2168,7 @@ again:
 
         if (c == '/' || c == '\\') {
             if (c == '\\') {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                    LXB_URL_ERROR_TYPE_INVALID_REVERSE_SOLIDUS);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2175,7 +2255,7 @@ again:
             if (override_state == LXB_URL_STATE__UNDEF && p - begin == 2
                 && lxb_url_windows_drive_letter(begin, p))
             {
-                status = lxb_url_log_append(parser, begin,
+                status = lxb_url_log_append(parser, begin, end,
                     LXB_URL_ERROR_TYPE_FILE_INVALID_WINDOWS_DRIVE_LETTER_HOST);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2223,7 +2303,7 @@ again:
 
         if (lxb_url_is_special(url)) {
             if (c == '\\') {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                    LXB_URL_ERROR_TYPE_INVALID_REVERSE_SOLIDUS);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2352,7 +2432,7 @@ again:
                                   || lexbor_str_res_map_hex[p[0]] == 0xff
                                   || lexbor_str_res_map_hex[p[1]] == 0xff)))
             {
-                status = lxb_url_log_append(parser, tmp,
+                status = lxb_url_log_append(parser, tmp, end,
                                             LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2415,7 +2495,7 @@ again:
                                   || lexbor_str_res_map_hex[p[0]] == 0xff
                                   || lexbor_str_res_map_hex[p[1]] == 0xff)))
             {
-                status = lxb_url_log_append(parser, tmp,
+                status = lxb_url_log_append(parser, tmp, end,
                                             LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2437,7 +2517,7 @@ again:
                                   || lexbor_str_res_map_hex[p[0]] == 0xff
                                   || lexbor_str_res_map_hex[p[1]] == 0xff)))
             {
-                status = lxb_url_log_append(parser, tmp,
+                status = lxb_url_log_append(parser, tmp, end,
                                             LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
                 if (status != LXB_STATUS_OK) {
                     lxb_url_parse_return(orig_data, buf, status);
@@ -2458,7 +2538,7 @@ again:
 
 failed_non_relative_url:
 
-    status = lxb_url_log_append(parser, p,
+    status = lxb_url_log_append(parser, p, end,
                            LXB_URL_ERROR_TYPE_MISSING_SCHEME_NON_RELATIVE_URL);
     if (status != LXB_STATUS_OK) {
         lxb_url_parse_return(orig_data, buf, status);
@@ -2468,7 +2548,7 @@ failed_non_relative_url:
 
 failed_host:
 
-    status = lxb_url_log_append(parser, p,
+    status = lxb_url_log_append(parser, p, end,
                                 LXB_URL_ERROR_TYPE_HOST_MISSING);
     if (status != LXB_STATUS_OK) {
         lxb_url_parse_return(orig_data, buf, status);
@@ -2504,7 +2584,7 @@ lxb_url_path_fast_path(lxb_url_parser_t *parser, lxb_url_t *url,
                     || lexbor_str_res_map_hex[p[1]] == 0xff
                     || lexbor_str_res_map_hex[p[2]] == 0xff)
                 {
-                    status = lxb_url_log_append(parser, p,
+                    status = lxb_url_log_append(parser, p, end,
                                                 LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
                     if (status != LXB_STATUS_OK) {
                         return NULL;
@@ -2537,7 +2617,7 @@ lxb_url_path_fast_path(lxb_url_parser_t *parser, lxb_url_t *url,
             else if (c == '\\' && lxb_url_is_special(url)) {
                 count += 1;
 
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                             LXB_URL_ERROR_TYPE_INVALID_REVERSE_SOLIDUS);
                 if (status != LXB_STATUS_OK) {
                     return NULL;
@@ -2656,7 +2736,7 @@ lxb_url_path_slow_path(lxb_url_parser_t *parser, lxb_url_t *url,
             cp = lxb_encoding_decode_valid_utf_8_single(&p, end);
 
             if (!lxb_url_is_url_codepoint(cp)) {
-                status = lxb_url_log_append(parser, tmp,
+                status = lxb_url_log_append(parser, tmp, end,
                                             LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
                 if (status != LXB_STATUS_OK) {
                     goto failed;
@@ -2696,7 +2776,7 @@ lxb_url_path_slow_path(lxb_url_parser_t *parser, lxb_url_t *url,
             }
         }
         else if (c == '\\' && lxb_url_is_special(url)) {
-            status = lxb_url_log_append(parser, p,
+            status = lxb_url_log_append(parser, p, end,
                                         LXB_URL_ERROR_TYPE_INVALID_REVERSE_SOLIDUS);
             if (status != LXB_STATUS_OK) {
                 goto failed;
@@ -2732,7 +2812,7 @@ lxb_url_path_slow_path(lxb_url_parser_t *parser, lxb_url_t *url,
             *sbuf++ = lexbor_str_res_char_to_two_hex_value[c][0];
             *sbuf++ = lexbor_str_res_char_to_two_hex_value[c][1];
 
-            status = lxb_url_log_append(parser, p,
+            status = lxb_url_log_append(parser, p, end,
                                         LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
             if (status != LXB_STATUS_OK) {
                 goto failed;
@@ -2760,7 +2840,7 @@ lxb_url_path_slow_path(lxb_url_parser_t *parser, lxb_url_t *url,
                 || lexbor_str_res_map_hex[p[1]] == 0xff
                 || lexbor_str_res_map_hex[p[2]] == 0xff)
             {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                             LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
                 if (status != LXB_STATUS_OK) {
                     goto failed;
@@ -2786,7 +2866,7 @@ lxb_url_path_slow_path(lxb_url_parser_t *parser, lxb_url_t *url,
         }
         else {
             if (lxb_url_codepoint_alphanumeric[c] == 0xFF) {
-                status = lxb_url_log_append(parser, p,
+                status = lxb_url_log_append(parser, p, end,
                                             LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
                 if (status != LXB_STATUS_OK) {
                     goto failed;
@@ -3025,7 +3105,7 @@ lxb_url_leading_trailing(lxb_url_parser_t *parser,
     }
 
     if (p != *data) {
-        status = lxb_url_log_append(parser, *data,
+        status = lxb_url_log_append(parser, *data, end,
                                     LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
         if (status != LXB_STATUS_OK) {
             return status;
@@ -3043,7 +3123,7 @@ lxb_url_leading_trailing(lxb_url_parser_t *parser,
     }
 
     if (end != *data + *length) {
-        status = lxb_url_log_append(parser, end,
+        status = lxb_url_log_append(parser, end, *data + *length,
                                     LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
         if (status != LXB_STATUS_OK) {
             return status;
@@ -3087,7 +3167,7 @@ lxb_url_remove_tab_newline(lxb_url_parser_t *parser,
 
 oh_my:
 
-    status = lxb_url_log_append(parser, p,
+    status = lxb_url_log_append(parser, p, end,
                                 LXB_URL_ERROR_TYPE_INVALID_URL_UNIT);
     if (status != LXB_STATUS_OK) {
         return NULL;
@@ -3364,7 +3444,7 @@ lxb_url_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
 
     if (data < end && *data == '[') {
         if (end[-1] != ']') {
-            status = lxb_url_log_append(parser, &end[-1],
+            status = lxb_url_log_append(parser, &end[-1], end,
                                         LXB_URL_ERROR_TYPE_IPV6_UNCLOSED);
             if (status != LXB_STATUS_OK) {
                 return status;
@@ -3446,7 +3526,7 @@ lxb_url_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
         c = *p++;
 
         if (c < 128 && lxb_url_map_forbidden_domain_cp[c] != 0xff) {
-            status = lxb_url_log_append(parser, p - 1,
+            status = lxb_url_log_append(parser, p - 1, end,
                                  LXB_URL_ERROR_TYPE_DOMAIN_INVALID_CODE_POINT);
             if (status != LXB_STATUS_OK) {
                 return status;
@@ -3458,6 +3538,9 @@ lxb_url_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
 
     if (lxb_url_is_ipv4(parser, domain->data, end)) {
         status = lxb_url_ipv4_parse(parser, domain->data, end, &ipv4);
+
+        (void) lexbor_str_destroy(domain, mraw, false);
+
         if (status != LXB_STATUS_OK) {
             return status;
         }
@@ -3496,7 +3579,7 @@ lxb_url_host_idna_cb(const lxb_char_t *data, size_t len, void *ctx)
 
 lxb_inline lxb_status_t
 lxb_url_ipv4_append(lxb_url_parser_t *parser, const lxb_char_t *data,
-                    const lxb_char_t *end, uint64_t *ipv,
+                    const lxb_char_t *end, const lxb_char_t *log_end, uint64_t *ipv,
                     int *out_of, unsigned i)
 {
     lxb_status_t status;
@@ -3510,7 +3593,7 @@ lxb_url_ipv4_append(lxb_url_parser_t *parser, const lxb_char_t *data,
             goto failed;
         }
 
-        status = lxb_url_log_append(parser, data,
+        status = lxb_url_log_append(parser, data, log_end,
                                     LXB_URL_ERROR_TYPE_IPV4_NON_DECIMAL_PART);
         if (status != LXB_STATUS_OK) {
             return status;
@@ -3518,7 +3601,7 @@ lxb_url_ipv4_append(lxb_url_parser_t *parser, const lxb_char_t *data,
     }
 
     if (ipv[i] > 255) {
-        status = lxb_url_log_append(parser, data,
+        status = lxb_url_log_append(parser, data, log_end,
                                     LXB_URL_ERROR_TYPE_IPV4_OUT_OF_RANGE_PART);
         if (status != LXB_STATUS_OK) {
             return status;
@@ -3533,7 +3616,7 @@ lxb_url_ipv4_append(lxb_url_parser_t *parser, const lxb_char_t *data,
 
 failed:
 
-    status = lxb_url_log_append(parser, data, type);
+    status = lxb_url_log_append(parser, data, log_end, type);
     if (status != LXB_STATUS_OK) {
         return status;
     }
@@ -3575,7 +3658,7 @@ lxb_url_ipv4_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
                 goto failed;
             }
 
-            status = lxb_url_ipv4_append(parser, begin, p, parts, &out_of, ++i);
+            status = lxb_url_ipv4_append(parser, begin, p, end, parts, &out_of, ++i);
             if (status != LXB_STATUS_OK) {
                 return status;
             }
@@ -3592,13 +3675,13 @@ lxb_url_ipv4_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
             goto failed;
         }
 
-        status = lxb_url_ipv4_append(parser, begin, p, parts, &out_of, ++i);
+        status = lxb_url_ipv4_append(parser, begin, p, end, parts, &out_of, ++i);
         if (status != LXB_STATUS_OK) {
             return status;
         }
     }
     else if (p[-1] == '.') {
-        status = lxb_url_log_append(parser, begin,
+        status = lxb_url_log_append(parser, begin, end,
                                     LXB_URL_ERROR_TYPE_IPV4_EMPTY_PART);
         if (status != LXB_STATUS_OK) {
             return status;
@@ -3629,7 +3712,7 @@ lxb_url_ipv4_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
 
 failed:
 
-    status = lxb_url_log_append(parser, begin, type);
+    status = lxb_url_log_append(parser, begin, end, type);
     if (status != LXB_STATUS_OK) {
         return status;
     }
@@ -3781,7 +3864,7 @@ lxb_url_parse_host_ipv6(lxb_url_parser_t *parser, const lxb_char_t *data,
 
     if (data < data + length && *data == '[') {
         if (data[length - 1] != ']') {
-            (void) lxb_url_log_append(parser, &data[length - 1],
+            (void) lxb_url_log_append(parser, &data[length - 1], data + length,
                                       LXB_URL_ERROR_TYPE_IPV6_UNCLOSED);
 
             status = LXB_STATUS_ERROR_UNEXPECTED_DATA;
@@ -3942,7 +4025,7 @@ done:
 
 failed:
 
-    status = lxb_url_log_append(parser, p, err_type);
+    status = lxb_url_log_append(parser, p, end, err_type);
     if (status != LXB_STATUS_OK) {
         return status;
     }
@@ -4036,7 +4119,7 @@ lxb_url_ipv4_in_ipv6_parse(lxb_url_parser_t *parser, const lxb_char_t **data,
 
 failed:
 
-    status = lxb_url_log_append(parser, p, err_type);
+    status = lxb_url_log_append(parser, p, end, err_type);
     if (status != LXB_STATUS_OK) {
         return status;
     }
@@ -4064,7 +4147,7 @@ lxb_url_opaque_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
         c = *p++;
 
         if (c < 128 && lxb_url_map_forbidden_host_cp[c] != 0xff) {
-            status = lxb_url_log_append(parser, p - 1,
+            status = lxb_url_log_append(parser, p - 1, end,
                                    LXB_URL_ERROR_TYPE_HOST_INVALID_CODE_POINT);
             if (status != LXB_STATUS_OK) {
                 return status;

--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -3458,9 +3458,6 @@ lxb_url_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
 
     if (lxb_url_is_ipv4(parser, domain->data, end)) {
         status = lxb_url_ipv4_parse(parser, domain->data, end, &ipv4);
-
-        (void) lexbor_str_destroy(domain, mraw, false);
-
         if (status != LXB_STATUS_OK) {
             return status;
         }

--- a/source/lexbor/url/url.h
+++ b/source/lexbor/url/url.h
@@ -179,6 +179,11 @@ lxb_url_t;
 typedef struct {
     lxb_url_t          *url;
     lexbor_mraw_t      *mraw;
+    /*
+     * Error contexts are owned, null-terminated copies of the suffix of the
+     * parsed input range. They remain valid until parser clean or destroy,
+     * even if entries are popped or the input and URL memory are freed.
+     */
     lexbor_plog_t      *log;
 
     lxb_unicode_idna_t *idna;

--- a/test/lexbor/url/errors.c
+++ b/test/lexbor/url/errors.c
@@ -79,6 +79,110 @@ TEST_BEGIN(empty_host_after_userinfo)
 }
 TEST_END
 
+TEST_BEGIN(owned_error_context)
+{
+    lxb_url_parser_t parser;
+    lxb_url_t *url;
+    lexbor_plog_entry_t *error;
+    lxb_char_t *input;
+    size_t length;
+    static const struct {
+        const char           *input;
+        const char           *context;
+        lxb_url_error_type_t  type;
+    } entries[] = {
+        {"http://1.2.3.4.5/", "5", LXB_URL_ERROR_TYPE_IPV4_TOO_MANY_PARTS},
+        {"http://0x7f.0.0.1/", "0x7f.0.0.1", LXB_URL_ERROR_TYPE_IPV4_NON_DECIMAL_PART},
+        {"http://example.org/%", "%", LXB_URL_ERROR_TYPE_INVALID_URL_UNIT},
+        {"http://example.org/\n%", "%", LXB_URL_ERROR_TYPE_INVALID_URL_UNIT},
+        {"http://example.org/ ", " ", LXB_URL_ERROR_TYPE_INVALID_URL_UNIT},
+        {"http://exa%23mple.org/", "#mple.org",
+         LXB_URL_ERROR_TYPE_DOMAIN_INVALID_CODE_POINT}
+    };
+
+    test_eq(lxb_url_parser_init(&parser, NULL), LXB_STATUS_OK);
+
+    for (size_t i = 0; i < sizeof(entries) / sizeof(entries[0]); i++) {
+        length = strlen(entries[i].input);
+        input = lexbor_malloc(length);
+        test_ne(input, NULL);
+        memcpy(input, entries[i].input, length);
+
+        url = lxb_url_parse(&parser, NULL, input, length);
+        lexbor_free(input);
+        lxb_url_destroy(url);
+
+        /* The log must also survive destruction of the URL arena. */
+        lxb_url_parser_memory_destroy(&parser);
+        test_ne(parser.log, NULL);
+        error = lexbor_array_obj_pop(&parser.log->list);
+        test_ne(error, NULL);
+        test_eq(error->id, entries[i].type);
+        test_eq_str(error->data, entries[i].context);
+
+        /* Popped entries must not prevent their contexts being reclaimed. */
+        lxb_url_parser_clean(&parser);
+        lxb_url_parser_destroy(&parser, false);
+        test_eq(lxb_url_parser_init(&parser, NULL), LXB_STATUS_OK);
+    }
+
+    lxb_url_parser_memory_destroy(&parser);
+    lxb_url_parser_destroy(&parser, false);
+}
+TEST_END
+
+TEST_BEGIN(ipv4_temporary_memory)
+{
+    lxb_url_parser_t parser;
+    lxb_url_t *url;
+    static const lexbor_str_t input = lexbor_str("http://127.0.0.1/");
+
+    test_eq(lxb_url_parser_init(&parser, NULL), LXB_STATUS_OK);
+
+    for (size_t i = 0; i < 100; i++) {
+        url = lxb_url_parse(&parser, NULL, input.data, input.length);
+        test_ne(url, NULL);
+        lxb_url_destroy(url);
+        lxb_url_parser_clean(&parser);
+        test_eq_size(lexbor_mraw_reference_count(parser.mraw), 0UL);
+    }
+
+    lxb_url_parser_memory_destroy(&parser);
+    lxb_url_parser_destroy(&parser, false);
+}
+TEST_END
+
+TEST_BEGIN(many_error_contexts)
+{
+    lxb_url_parser_t parser;
+    lxb_url_t *url;
+    lexbor_plog_entry_t *error;
+    lxb_char_t input[4096];
+    const lxb_char_t *first;
+    static const char prefix[] = "http://example.org/#";
+    size_t prefix_length = sizeof(prefix) - 1;
+
+    memcpy(input, prefix, prefix_length);
+    memset(input + prefix_length, '^', sizeof(input) - prefix_length);
+    test_eq(lxb_url_parser_init(&parser, NULL), LXB_STATUS_OK);
+    url = lxb_url_parse(&parser, NULL, input, sizeof(input));
+    test_ne(url, NULL);
+    test_eq_size(lexbor_plog_length(parser.log), sizeof(input) - prefix_length);
+
+    error = lexbor_array_obj_get(&parser.log->list, 0);
+    first = error->data;
+    test_eq_size(strlen((const char *) first), sizeof(input) - prefix_length);
+
+    for (size_t i = 0; i < lexbor_plog_length(parser.log); i++) {
+        error = lexbor_array_obj_get(&parser.log->list, i);
+        test_eq(error->data, first + i);
+    }
+
+    lxb_url_parser_memory_destroy(&parser);
+    lxb_url_parser_destroy(&parser, false);
+}
+TEST_END
+
 int
 main(int argc, const char * argv[])
 {
@@ -86,6 +190,9 @@ main(int argc, const char * argv[])
 
     TEST_ADD(use_log_after_free);
     TEST_ADD(empty_host_after_userinfo);
+    TEST_ADD(owned_error_context);
+    TEST_ADD(ipv4_temporary_memory);
+    TEST_ADD(many_error_contexts);
 
     TEST_RUN("lexbor/url/errors");
     TEST_RELEASE();


### PR DESCRIPTION
The lexbor_str_destroy() call frees and subsequently poisons the domain string's memory region, but the character where parsing failed is added to the logs (https://github.com/lexbor/lexbor/blob/21c907010afbace3df43e9cb42071d988428084a/source/lexbor/url/url.c#L3617), causing a use-after-poison error if the logs are consumed.

Since lexbor uses an arena allocator, skipping the explicit `lexbor_str_destroy()` call should not cause a memory leak — the memory will be reclaimed when the arena itself is freed.

Found in https://github.com/php/php-src/pull/22826