### PR TITLE
URL: Fix parsing of usernames containing `@`

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -1753,16 +1753,13 @@ again:
                         break;
                     }
 
-                    if (pswd == NULL || !at_sign) {
-                        tmp = (pswd != NULL) ? pswd - 1 : p;
-
-                        if (tmp > begin) {
-                            status = lxb_url_percent_encode_after_utf_8(begin, tmp,
-                                                        &url->username, url->mraw,
-                                                        LXB_URL_MAP_USERINFO, false);
-                            if (status != LXB_STATUS_OK) {
-                                lxb_url_parse_return(orig_data, buf, status);
-                            }
+                    tmp = (pswd != NULL) ? pswd - 1 : p;
+                    if (tmp > begin) {
+                        status = lxb_url_percent_encode_after_utf_8(begin, tmp,
+                                                    &url->username, url->mraw,
+                                                    LXB_URL_MAP_USERINFO, false);
+                        if (status != LXB_STATUS_OK) {
+                            lxb_url_parse_return(orig_data, buf, status);
                         }
                     }
 

--- a/test/files/lexbor/url/username_password.ton
+++ b/test/files/lexbor/url/username_password.ton
@@ -129,5 +129,16 @@
         "url": "https://user:pass@",
         "failed": true,
         "encoding": "utf-8"
-    }
+    },
+    /* 13 */
+    {
+        "url": "http://user@name:pass@word@localhost/",
+        "done": "http://user%40name:pass%40word@localhost/",
+        "username": "user%40name",
+        "password": "pass%40word",
+        "host": "localhost",
+        "path": "/",
+        "failed": false,
+        "encoding": "utf-8"
+    },
 ]


### PR DESCRIPTION
Fixes lexbor/lexbor#399.

----------------

<strike>Not entirely sure this is correct, because the algorithm specified in the specification is confusing me:

> If atSignSeen is true, then prepend "%40" to buffer. 

I think this should read “append” instead of “prepend”. But it seems that the implementation in Lexbor does not strictly follow the algorithm (e.g. no `buffer` variable).

Please carefully review this, but it seems to do the right thing.</strike>