### PR TITLE
 Core: Reuse object memory for freed object tracking in dobject (Object Pool).

### DIFF
--- a/source/lexbor/core/dobject.c
+++ b/source/lexbor/core/dobject.c
@@ -32,6 +32,11 @@ lexbor_dobject_init(lexbor_dobject_t *dobject,
         return LXB_STATUS_ERROR_WRONG_ARGS;
     }
 
+    if (struct_size < sizeof(lexbor_dobject_free_list_node_t)) {
+        // raise struct size ensure there is enough room for the pointers in the free list
+        struct_size = sizeof(lexbor_dobject_free_list_node_t);
+    }
+
     /* Set params */
     dobject->allocated = 0UL;
     dobject->struct_size = struct_size;
@@ -50,12 +55,8 @@ lexbor_dobject_init(lexbor_dobject_t *dobject,
                               dobject->mem->chunk->size);
 #endif
 
-    /* Array */
-    dobject->cache = lexbor_array_create();
-
-    status = lexbor_array_init(dobject->cache, chunk_size);
-    if (status)
-        return status;
+    /* Setting up the free-list */
+    dobject->freelist = NULL;
 
     return LXB_STATUS_OK;
 }
@@ -67,7 +68,7 @@ lexbor_dobject_clean(lexbor_dobject_t *dobject)
         dobject->allocated = 0UL;
 
         lexbor_mem_clean(dobject->mem);
-        lexbor_array_clean(dobject->cache);
+        dobject->freelist = NULL;
     }
 }
 
@@ -78,7 +79,6 @@ lexbor_dobject_destroy(lexbor_dobject_t *dobject, bool destroy_self)
         return NULL;
 
     dobject->mem = lexbor_mem_destroy(dobject->mem, true);
-    dobject->cache = lexbor_array_destroy(dobject->cache, true);
 
     if (destroy_self == true) {
         return lexbor_free(dobject);
@@ -92,17 +92,17 @@ lexbor_dobject_alloc(lexbor_dobject_t *dobject)
 {
     void *data;
 
-    if (lexbor_array_length(dobject->cache) != 0) {
+    if (dobject->freelist != NULL) {
         dobject->allocated++;
+        
+        // pop the first node from the free list
+        data = dobject->freelist;
+        dobject->freelist = dobject->freelist->next;
 
 #if defined(LEXBOR_HAVE_ADDRESS_SANITIZER)
-        data = lexbor_array_pop(dobject->cache);
         ASAN_UNPOISON_MEMORY_REGION(data, dobject->struct_size);
-
-        return data;
-#else
-        return lexbor_array_pop(dobject->cache);
 #endif
+        return data;
     }
 
     data = lexbor_mem_alloc(dobject->mem, dobject->struct_size);
@@ -142,12 +142,13 @@ lexbor_dobject_free(lexbor_dobject_t *dobject, void *data)
     ASAN_POISON_MEMORY_REGION(data, dobject->struct_size);
 #endif
 
-    if (lexbor_array_push(dobject->cache, data) == LXB_STATUS_OK) {
-        dobject->allocated--;
-        return NULL;
-    }
+    // insert newly freed object slot to the head of the free list
+    dobject->allocated--;
+    lexbor_dobject_free_list_node_t *new_node = (lexbor_dobject_free_list_node_t *)data;
+    new_node->next = dobject->freelist;
+    dobject->freelist = new_node;
 
-    return data;
+    return NULL;
 }
 
 void *

--- a/source/lexbor/core/dobject.c
+++ b/source/lexbor/core/dobject.c
@@ -94,14 +94,15 @@ lexbor_dobject_alloc(lexbor_dobject_t *dobject)
 
     if (dobject->freelist != NULL) {
         dobject->allocated++;
-        
+
         // pop the first node from the free list
         data = dobject->freelist;
-        dobject->freelist = dobject->freelist->next;
 
 #if defined(LEXBOR_HAVE_ADDRESS_SANITIZER)
+        // unpoision the (re)allocated region
         ASAN_UNPOISON_MEMORY_REGION(data, dobject->struct_size);
 #endif
+        dobject->freelist = dobject->freelist->next;
         return data;
     }
 
@@ -138,15 +139,16 @@ lexbor_dobject_free(lexbor_dobject_t *dobject, void *data)
         return NULL;
     }
 
-#if defined(LEXBOR_HAVE_ADDRESS_SANITIZER)
-    ASAN_POISON_MEMORY_REGION(data, dobject->struct_size);
-#endif
-
     // insert newly freed object slot to the head of the free list
     dobject->allocated--;
     lexbor_dobject_free_list_node_t *new_node = (lexbor_dobject_free_list_node_t *)data;
     new_node->next = dobject->freelist;
     dobject->freelist = new_node;
+
+#if defined(LEXBOR_HAVE_ADDRESS_SANITIZER)
+    // poison the freed region
+    ASAN_POISON_MEMORY_REGION(data, dobject->struct_size);
+#endif
 
     return NULL;
 }

--- a/source/lexbor/core/dobject.h
+++ b/source/lexbor/core/dobject.h
@@ -15,10 +15,13 @@ extern "C" {
 #include "lexbor/core/mem.h"
 #include "lexbor/core/array.h"
 
+typedef struct lexbor_dobject_free_list_node {
+    struct lexbor_dobject_free_list_node * next;
+} lexbor_dobject_free_list_node_t;
 
 typedef struct {
     lexbor_mem_t   *mem;
-    lexbor_array_t *cache;
+    lexbor_dobject_free_list_node_t *freelist;
 
     size_t         allocated;
     size_t         struct_size;
@@ -66,7 +69,17 @@ lexbor_dobject_allocated(lexbor_dobject_t *dobject)
 lxb_inline size_t
 lexbor_dobject_cache_length(lexbor_dobject_t *dobject)
 {
-    return lexbor_array_length(dobject->cache);
+    // I am assuming this function is not performance critical
+    // It used to be O(1) but now is O(n) in the length of the free-list
+
+    size_t free_count = 0;
+    lexbor_dobject_free_list_node_t *current_node = dobject->freelist;
+    while (current_node != NULL) {
+        free_count++;
+        current_node = current_node->next;
+    }
+
+    return free_count;
 }
 
 /*

--- a/source/lexbor/core/dobject.h
+++ b/source/lexbor/core/dobject.h
@@ -15,6 +15,10 @@ extern "C" {
 #include "lexbor/core/mem.h"
 #include "lexbor/core/array.h"
 
+#if defined(LEXBOR_HAVE_ADDRESS_SANITIZER)
+    #include <sanitizer/asan_interface.h>
+#endif
+
 typedef struct lexbor_dobject_free_list_node {
     struct lexbor_dobject_free_list_node * next;
 } lexbor_dobject_free_list_node_t;
@@ -76,7 +80,14 @@ lexbor_dobject_cache_length(lexbor_dobject_t *dobject)
     lexbor_dobject_free_list_node_t *current_node = dobject->freelist;
     while (current_node != NULL) {
         free_count++;
+#if defined(LEXBOR_HAVE_ADDRESS_SANITIZER)
+        // unpoison and reposion the chunk only for the free-list walk
+        ASAN_UNPOISON_MEMORY_REGION(current_node, dobject->struct_size);
+#endif
         current_node = current_node->next;
+#if defined(LEXBOR_HAVE_ADDRESS_SANITIZER)
+        ASAN_POISON_MEMORY_REGION(current_node, dobject->struct_size);
+#endif
     }
 
     return free_count;

--- a/test/lexbor/core/dobject.c
+++ b/test/lexbor/core/dobject.c
@@ -116,21 +116,14 @@ TEST_BEGIN(obj_alloc_free_alloc)
     lexbor_dobject_init(&dobj, 128, sizeof(test_data_t));
 
     test_data_t *data = lexbor_dobject_alloc(&dobj);
-
-    data->a = 159753UL;
-    data->b = 'L';
-    data->c = 12;
-
     lexbor_dobject_free(&dobj, data);
 
     test_eq_size(lexbor_dobject_allocated(&dobj), 0UL);
     test_eq_size(lexbor_dobject_cache_length(&dobj), 1UL);
 
-    data = lexbor_dobject_alloc(&dobj);
+    test_data_t *new_data = lexbor_dobject_alloc(&dobj);
 
-    test_eq_size(data->a, 159753UL);
-    test_eq_char(data->b, 'L');
-    test_eq_int(data->c, 12);
+    test_eq_type((void*)new_data, (void*)data, "%p", !=);
 
     lexbor_dobject_destroy(&dobj, false);
 }


### PR DESCRIPTION
This pull request replaces the "freed object cache" (`lexbor_array_t`) with a simple linked list that reuses the freed objects' memory.

### Description

The separate freed object cache implementation introduces one pointer-sized (typically 8 bytes on 64-bit systems) per object slot in dobject, not counting any other accounting overheads in the `lexbor_array_t`. Considering that the objects placed in dobject typically have a `struct_size` range from 24 to 40 bytes, this extra accounting overhead is significant.

In this pull request, the "freed object cache" is replaced with a simple singly linked list. Importantly, this list reuses the memory of freed objects for its pointers, using no extra memory (assuming `struct_size` is larger than the size of a pointer). 

Using the [scenario presented in the documentation](https://lexbor.com/modules/core/#id7) as an example. Here, objects 0, 2, and 4 are allocated, and objects 1 and 3 are freed. A `freelist` field replaces the `cache` field in `lexbor_dobject_t` and serves as a pointer to the start of the free list. In this scenario, `freelist` points to the memory location of object 1, which then contains a pointer to object 3, which contains a null pointer, marking the end of the free list.

When a new allocation is requested, the head of the free list (in this case, object 1) is popped off. When an object is freed, it is inserted at the head of the list. This preserves the FIFO behavior of the original "freed object cache" and the cache benefit it may bring. Inserting and removing nodes at the head of a singly linked list are O(1) and introduce no additional overhead.

Even though freed objects are reused as part of the free list, the entire freed object, including the free list pointer, is poisoned by ASAN to detect use-after-free errors. They are only briefly unpoisoned when dobject functions need to access them.

I have confirmed that the modified code passes all unit tests with or without ASAN enabled (with the exception of one test that had to be modified, see "caveats" below)
```
Chunk Memory (mem):
+-----+-----+-----+-----+-----+--------+
| obj | ptr | obj | null| obj | free   |
|  0  |  to |  2  | ptr |  4  | space  |
|     |  3  |     |     |     |        |
+-----+-----+-----+-----+-----+--------+
         ^ \         ^
         |  \________|
freelist 
(in lexbor_dobject_t)
```

### (Crudely measured) Savings
I did some rather crude measurements with lxb_html_tokenizer based on [the example](https://lexbor.com/modules/html/#example-usage) in the documentation. "after init" is after calling `lxb_html_tokenizer_init`, "after begin" is after calling `lxb_html_tokenizer_begin`, and "after processing" is after running the [main page](https://lexbor.com/) of the lexbor website through the tokenizer. Memory usage measured by wrapping C's memory functions and plugging in using `lexbor_memory_setup`.

|   | after init|  after begin | after processing  |
|---|---|---|---|
| Original | 769816B |  853608B | 855752B  |
|  This PR | 700112B  |  773568B | 775712B | 
| Diff        | -69704B| -80040B | -80040B|
|              | - 9.05%| -9.38% | -9.35%|

This represents 69-80KB of savings or about 9% from this change alone.

### Caveats

- `lexbor_dobject_cache_length`: This function is originally just reading the length from the "freed object cache". However, the free list does not support O(1) length access. This has been re-implemented as O(n) linked list traversal. A search of the codebase shows that the only external use of this function is in a single unit test, so I assumed its performance was not important.
- The `obj_alloc_free_alloc` test in the dobject unit test: This test had to be modified because the original implementation checked explicitly that the freed and (re)allocated object is unmodified. Due to the free list implementation, writing a pointer into the first 8 bytes of the object causes the original implementation to fail. I don't think expecting/depending on a freed object to be unmodified is sound coding, so I replaced the test with a simple check that the reallocated object had the same address as the freed object.
-  objects smaller than a pointer: The memory reuse requires that the object at least have enough space to hold one single pointer. If a `struct_size` of less than `sizeof(void *)` is provided, the new implementation forces `struct_size` to be at least `sizeof(void *)`. I was not able to locate any instances in the codebase where the `struct_size` is less than 8, but technically, in that case, the object storage would be less compact, and the amount of saved memory would be less than one pointer per object slot.