### PR TITLE
Add support for using custom percent-encoding maps

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -28,20 +28,6 @@
 
 
 typedef enum {
-    LXB_URL_MAP_UNDEF         = 0x00,
-    LXB_URL_MAP_C0            = 0x01,
-    LXB_URL_MAP_FRAGMENT      = 0x02,
-    LXB_URL_MAP_QUERY         = 0x04,
-    LXB_URL_MAP_SPECIAL_QUERY = 0x08,
-    LXB_URL_MAP_PATH          = 0x10,
-    LXB_URL_MAP_USERINFO      = 0x20,
-    LXB_URL_MAP_COMPONENT     = 0x40,
-    LXB_URL_MAP_X_WWW_FORM    = 0x80,
-    LXB_URL_MAP_ALL           = 0xff
-}
-lxb_url_map_type_t;
-
-typedef enum {
     LXB_URL_HOST_OPT_UNDEF       = 0 << 0,
     LXB_URL_HOST_OPT_NOT_SPECIAL = 1 << 0,
     LXB_URL_HOST_OPT_DECODE      = 1 << 1,
@@ -567,13 +553,6 @@ lxb_url_percent_encode_after_encoding(const lxb_char_t *data,
                                       const lxb_encoding_data_t *encoding,
                                       lxb_url_map_type_t enmap,
                                       bool space_as_plus);
-
-static lxb_status_t
-lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
-                                   const lxb_char_t *end, lexbor_str_t *str,
-                                   lexbor_mraw_t *mraw,
-                                   lxb_url_map_type_t enmap,
-                                   bool space_as_plus);
 
 static lxb_status_t
 lxb_url_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
@@ -3161,6 +3140,10 @@ lxb_url_scheme_find(const lxb_char_t *data, size_t length)
     return &lxb_url_scheme_res[LXB_URL_SCHEMEL_TYPE__UNKNOWN];
 }
 
+const uint8_t *lxb_url_get_percent_encoding_map(void) {
+    return lxb_url_map;
+}
+
 static lxb_status_t
 lxb_url_percent_encode_after_encoding(const lxb_char_t *data,
                                       const lxb_char_t *end, lexbor_str_t *str,
@@ -3280,12 +3263,13 @@ lxb_url_percent_encode_after_encoding(const lxb_char_t *data,
     return LXB_STATUS_OK;
 }
 
-static lxb_status_t
-lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
-                                   const lxb_char_t *end, lexbor_str_t *str,
-                                   lexbor_mraw_t *mraw,
-                                   lxb_url_map_type_t enmap,
-                                   bool space_as_plus)
+lxb_status_t
+lxb_url_percent_encode_after_utf_8_ex(const lxb_char_t *data,
+                                      const lxb_char_t *end, lexbor_str_t *str,
+                                      lexbor_mraw_t *mraw,
+                                      lxb_url_map_type_t enmap,
+                                      bool space_as_plus,
+                                      const uint8_t *url_map)
 {
     size_t length;
     lxb_status_t status;
@@ -3298,7 +3282,7 @@ lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
     /* Only valid for UTF-8. */
 
     while (p < end) {
-        if (lxb_url_map[*p++] & enmap) {
+        if (url_map[*p++] & enmap) {
             length += 2;
         }
     }
@@ -3317,7 +3301,7 @@ lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
         if (space_as_plus && c == ' ') {
             *pd++ = '+';
         }
-        else if (lxb_url_map[c] & enmap) {
+        else if (url_map[c] & enmap) {
             *pd++ = '%';
             *pd++ = lexbor_str_res_char_to_two_hex_value[c][0];
             *pd++ = lexbor_str_res_char_to_two_hex_value[c][1];
@@ -3333,6 +3317,16 @@ lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
     str->length += pd - &str->data[str->length];
 
     return LXB_STATUS_OK;
+}
+
+lxb_status_t
+lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
+                                   const lxb_char_t *end, lexbor_str_t *str,
+                                   lexbor_mraw_t *mraw,
+                                   lxb_url_map_type_t enmap,
+                                   bool space_as_plus)
+{
+    return lxb_url_percent_encode_after_utf_8_ex(data, end, str, mraw, enmap, space_as_plus, lxb_url_map);
 }
 
 static lxb_status_t

--- a/source/lexbor/url/url.h
+++ b/source/lexbor/url/url.h
@@ -81,6 +81,20 @@ typedef enum {
 }
 lxb_url_state_t;
 
+typedef enum {
+    LXB_URL_MAP_UNDEF         = 0x00,
+    LXB_URL_MAP_C0            = 0x01,
+    LXB_URL_MAP_FRAGMENT      = 0x02,
+    LXB_URL_MAP_QUERY         = 0x04,
+    LXB_URL_MAP_SPECIAL_QUERY = 0x08,
+    LXB_URL_MAP_PATH          = 0x10,
+    LXB_URL_MAP_USERINFO      = 0x20,
+    LXB_URL_MAP_COMPONENT     = 0x40,
+    LXB_URL_MAP_X_WWW_FORM    = 0x80,
+    LXB_URL_MAP_ALL           = 0xff
+}
+lxb_url_map_type_t;
+
 /*
  * New values can only be added downwards.
  * Before LXB_URL_SCHEMEL_TYPE__LAST_ENTRY.
@@ -279,6 +293,55 @@ lxb_url_parser_destroy(lxb_url_parser_t *parser, bool destroy_self);
  */
 LXB_API void
 lxb_url_parser_memory_destroy(lxb_url_parser_t *parser);
+
+/*
+ * Returns the default percent-encoding map.
+ *
+ * @return uint8_t *.
+ */
+LXB_API const uint8_t *lxb_url_get_percent_encoding_map(void);
+
+/*
+ * Percent-encodes the input data according to the specified url_map and
+ * percent-encoding set, writing the result into the output buffer.
+ *
+ * @param[in]  lxb_char_t *. Not NULL.
+ * @param[in]  const lxb_char_t *. Not NULL.
+ * @param[out] lexbor_str_t *. Not NULL.
+ * @param[in]  lexbor_mraw_t *. Not NULL.
+ * @param[in]  lxb_url_map_type_t.
+ * @param[in]  bool. If true, U+0020 SPACE is encoded as '+' instead of '%20'.
+ * @param[in]  const uint8_t *. Not NULL.
+ *
+ * @return LXB_STATUS_OK on success, or an error status code on allocation failure.
+ */
+LXB_API lxb_status_t
+lxb_url_percent_encode_after_utf_8_ex(const lxb_char_t *data,
+                                      const lxb_char_t *end, lexbor_str_t *str,
+                                      lexbor_mraw_t *mraw,
+                                      lxb_url_map_type_t enmap,
+                                      bool space_as_plus,
+                                      const uint8_t *url_map);
+
+/*
+ * Percent-encodes the input data according to the default percent-encoding map and
+ * the specified percent-encoding set, writing the result into the output buffer.
+ *
+ * @param[in]  lxb_char_t *. Not NULL.
+ * @param[in]  const lxb_char_t *. Not NULL.
+ * @param[out] lexbor_str_t *. Not NULL.
+ * @param[in]  lexbor_mraw_t *. Not NULL.
+ * @param[in]  lxb_url_map_type_t.
+ * @param[in]  bool. If true, U+0020 SPACE is encoded as '+' instead of '%20'.
+ *
+ * @return LXB_STATUS_OK on success, or an error status code on allocation failure.
+ */
+LXB_API lxb_status_t
+lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
+                                   const lxb_char_t *end, lexbor_str_t *str,
+                                   lexbor_mraw_t *mraw,
+                                   lxb_url_map_type_t enmap,
+                                   bool space_as_plus);
 
 /*
  * URL parser.


### PR DESCRIPTION
In order to implement the `Uri\WhatWg\url_percent_encode()` function in PHP as defined by https://wiki.php.net/rfc/uri_followup#percent-encoding_support needs, percent-encoding rules need to be adjusted (the "%" character is always percent-encoded, and the "/" character is percent-encoded by the `Uri\WhatWg\UrlPercentEncodingMode::PathSegment` mode).

That's why a `lxb_url_percent_encode_after_utf_8_ex()` function is added which accepts a custom percent-encoding map. The original `lxb_url_percent_encode_after_utf_8()` function is refactored so that it uses `lxb_url_percent_encode_after_utf_8()` under the hood.