### PR TITLE
cmake: Unconditionally include GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,12 +114,12 @@ ENDIF()
 ################
 ## RPATH
 #########################
+include(GNUInstallDirs)
+
 IF(APPLE)
     set(CMAKE_MACOSX_RPATH ON)
 
     set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
-ELSEIF(UNIX)
-    include(GNUInstallDirs)
 ENDIF()
 
 ################


### PR DESCRIPTION
This fixes that CMake configs and pkgconfig bindings were broken on Windows (and probably osx). This was detected by GPT 5.6 Sol while reviewing https://github.com/microsoft/vcpkg/pull/53849/ . Quoting it:

> - The installed `lexbor::lexbor` CMake target does not propagate its include directory, so consumers using only `find_package(lexbor CONFIG REQUIRED)` and `target_link_libraries(...)` cannot compile. The upstream target exposes only a build-tree include path in [`CMakeLists.txt`](https://github.com/lexbor/lexbor/blob/7e278c0188489bfce6b71ced0cc900cbb31e6244/CMakeLists.txt#L204-L208).

Note that this proposed fix makes the existing bit work without touching that line because the existing:

https://github.com/lexbor/lexbor/blob/7e278c0188489bfce6b71ced0cc900cbb31e6244/CMakeLists.txt#L204-L208

already tried to do this correctly. Unfortunately that is broken because without [`GNUInstallDirs`](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html), `${CMAKE_INSTALL_INCLUDEDIR}` is not set, so it effectively says `$<INSTALL_INTERFACE:>`.

> - The installed `lexbor.pc` files have empty `libdir` and `includedir` values, producing unusable `-I -L -llexbor` flags. [`lexbor.pc.in`](https://github.com/lexbor/lexbor/blob/7e278c0188489bfce6b71ced0cc900cbb31e6244/lexbor.pc.in) references GNU install-directory variables that are not initialized before configuration.