### PR TITLE
URL: Fix `lxb_url_serialize_fragment()` without a query

### DIFF
--- a/source/lexbor/url/url.c
+++ b/source/lexbor/url/url.c
@@ -4966,7 +4966,7 @@ lxb_status_t
 lxb_url_serialize_fragment(const lxb_url_t *url,
                            lexbor_serialize_cb_f cb, void *ctx)
 {
-    if (url->query.data != NULL) {
+    if (url->fragment.data != NULL) {
         return cb(url->fragment.data, url->fragment.length, ctx);
     }
 


### PR DESCRIPTION
The `lxb_url_serialize_fragment()` function checked if the query contained data before correctly serializing the fragment. Check for the fragment instead.